### PR TITLE
fix(core): Less error-parity checks (property-in-root, detached-ruleset-on-property, hex length)

### DIFF
--- a/packages/core/src/jess-error.ts
+++ b/packages/core/src/jess-error.ts
@@ -27,6 +27,7 @@ export type JessErrorCode =
   | 'eval/type-mismatch'
   | 'eval/invalid-statement'
   | 'eval/property-in-root'
+  | 'eval/ruleset-on-property'
   | 'extend/protected-boundary'
   | 'extend/not-found'
   | 'extend/not-accessible'
@@ -223,6 +224,12 @@ const TEMPLATES = new Map<JessErrorCode, Template>([
     summary: 'Properties must be inside selector blocks. They cannot be in the root',
     reason: 'The property "${what}" was evaluated at the root — most often a mixin or detached ruleset call that dropped its declarations into the top level.',
     fix: 'Put the property inside a selector block (e.g. call the mixin/detached ruleset from within a ruleset).'
+  }],
+
+  ['eval/ruleset-on-property', {
+    summary: 'Rulesets cannot be evaluated on a property',
+    reason: 'The value of "${what}" evaluated to a detached ruleset; a detached ruleset can only be called (e.g. `@dr();` inside a block), not used as a property value.',
+    fix: 'Call the detached ruleset in statement position instead of assigning it to a property.'
   }],
 
   // Extend

--- a/packages/core/src/jess-error.ts
+++ b/packages/core/src/jess-error.ts
@@ -26,6 +26,7 @@ export type JessErrorCode =
   | 'eval/bad-call-arity'
   | 'eval/type-mismatch'
   | 'eval/invalid-statement'
+  | 'eval/property-in-root'
   | 'extend/protected-boundary'
   | 'extend/not-found'
   | 'extend/not-accessible'
@@ -216,6 +217,12 @@ const TEMPLATES = new Map<JessErrorCode, Template>([
     summary: 'Value node is not valid as a statement',
     reason: '${what} is a value; it cannot stand on its own in a rules body — it was likely returned by a function/mixin or leaked from a detached ruleset.',
     fix: 'Wrap it in a declaration (property: value) or return a valid statement node (ruleset, declaration, at-rule).'
+  }],
+
+  ['eval/property-in-root', {
+    summary: 'Properties must be inside selector blocks. They cannot be in the root',
+    reason: 'The property "${what}" was evaluated at the root — most often a mixin or detached ruleset call that dropped its declarations into the top level.',
+    fix: 'Put the property inside a selector block (e.g. call the mixin/detached ruleset from within a ruleset).'
   }],
 
   // Extend

--- a/packages/core/src/tree/declaration.ts
+++ b/packages/core/src/tree/declaration.ts
@@ -17,6 +17,7 @@ import { List } from './list.js';
 import { Sequence, spaced } from './sequence.js';
 import { Operation } from './operation.js';
 import { N } from './node-type.js';
+import { makeJessError } from '../jess-error.js';
 import type { Call } from './call.js';
 import {
   OutputWriter,
@@ -2202,9 +2203,48 @@ export class Declaration<Opts extends DeclarationOptions = DeclarationOptions> e
 
   override evalNode(context: Context): MaybePromise<this | Nil> {
     const state = this.evalValueState(context);
+    const finalize = (resolved: DeclarationValueState<this> | Nil): this | Nil => {
+      if (resolved instanceof Nil) {
+        return resolved;
+      }
+      const out = this.materializeValueState(resolved);
+      out.assertNotDetachedRuleset();
+      return out;
+    };
     return isThenable<DeclarationValueState<this> | Nil>(state)
-      ? state.then((resolved: DeclarationValueState<this> | Nil) => resolved instanceof Nil ? resolved : this.materializeValueState(resolved))
-      : state instanceof Nil ? state : this.materializeValueState(state);
+      ? state.then(finalize)
+      : finalize(state);
+  }
+
+  /**
+   * A detached ruleset used as a property value (`a: @dr;`) is invalid — Less:
+   * "Rulesets cannot be evaluated on a property". A detached ruleset resolves to a
+   * `Mixin` (uncalled, the `@dr: { … }` body) or a `Rules` (a called output); a
+   * value `Collection` (a Rules subtype that legitimately groups value parts) is
+   * NOT flagged. Only regular property declarations are checked — a VarDeclaration
+   * `@x: { … }` is a valid detached-ruleset *definition*.
+   */
+  private assertNotDetachedRuleset(): void {
+    if (this.type !== 'Declaration') {
+      return;
+    }
+    let v: unknown = this.value;
+    if (isNode(v, N.List) || isNode(v, N.Sequence)) {
+      const items = (v as { value?: unknown[] }).value;
+      if (Array.isArray(items) && items.length === 1) {
+        v = items[0];
+      }
+    }
+    const t = (v as { type?: string } | null)?.type;
+    if (t === 'Mixin' || t === 'Rules') {
+      throw makeJessError({
+        code: 'eval/ruleset-on-property',
+        phase: 'eval',
+        ctx: this.sourceRoot?._treeContext,
+        node: this,
+        meta: { what: String(this.name?.valueOf?.() ?? this.name ?? 'property') }
+      });
+    }
   }
 
   /** @todo - move to visitors */

--- a/packages/core/src/tree/rules.ts
+++ b/packages/core/src/tree/rules.ts
@@ -4778,7 +4778,7 @@ export class Rules<V = never, O extends NodeOptions = RulesOptions & NodeOptions
     const printOptions = isRenderBuffer(bufferOrOptions) ? options : bufferOrOptions;
     const preSerializeRoot = sourceWasRoot ? printOptions?.preSerializeRoot : undefined;
     const serialize = (state: RulesRenderState): MaybePromise<string> => {
-      checkValidNodes(state.output?.rules, context);
+      checkValidNodes(state.output?.rules, context, sourceWasRoot);
       return isRenderBuffer(bufferOrOptions)
         ? writeRulesStateRenderOutput(bufferOrOptions, state, context, options)
         : renderRulesStateToString(state, context, bufferOrOptions);

--- a/packages/core/src/tree/util/__tests__/check-valid-nodes.test.ts
+++ b/packages/core/src/tree/util/__tests__/check-valid-nodes.test.ts
@@ -50,4 +50,17 @@ describe('checkValidNodes', () => {
     expect(() => checkValidNodes([])).not.toThrow();
     expect(() => checkValidNodes(undefined)).not.toThrow();
   });
+
+  it('throws property-in-root for a Declaration hoisted to the root via a call-output block', () => {
+    // A mixin / detached-ruleset call at the top level wraps its declarations in a
+    // Rules block; isRoot + inRootBlock marks a Declaration reached through one.
+    const decl = new Declaration({ name: 'prop', value: '1' });
+    expect(() => checkValidNodes([decl], undefined, true, true))
+      .toThrow(/Properties must be inside selector blocks/i);
+  });
+
+  it('does not flag a bare root Declaration (nil-selector stream, not call output)', () => {
+    const decl = new Declaration({ name: 'prop', value: '1' });
+    expect(() => checkValidNodes([decl], undefined, true, false)).not.toThrow();
+  });
 });

--- a/packages/core/src/tree/util/check-valid-nodes.ts
+++ b/packages/core/src/tree/util/check-valid-nodes.ts
@@ -17,7 +17,9 @@ import { makeJessError } from '../../jess-error.js';
  */
 export function checkValidNodes(
   rules: readonly Node[] | undefined,
-  context?: Context
+  context?: Context,
+  isRoot = false,
+  fromCallOutput = false
 ): void {
   if (!rules) {
     return;
@@ -25,6 +27,31 @@ export function checkValidNodes(
   const ctx = context?.treeContext;
   for (let i = 0; i < rules.length; i++) {
     const node = rules[i]!;
+    // Less: a property Declaration that a mixin / detached-ruleset CALL dropped at
+    // the root is invalid ("Properties must be inside selector blocks"). We only
+    // flag declarations reached through such a call's output block (see the Rules
+    // recursion below), not bare ones — nil-selector rulesets legitimately stream
+    // declarations to the buffer as an internal mechanism. VarDeclaration `@x:`
+    // and custom props are distinct node types and are never flagged.
+    if (isRoot && fromCallOutput && node.type === 'Declaration') {
+      throw makeJessError({
+        code: 'eval/property-in-root',
+        phase: 'eval',
+        ctx,
+        node,
+        meta: { what: String((node as { name?: unknown }).name ?? 'property') }
+      });
+    }
+    // Recurse into root-level `Rules` blocks (they flatten into the root at
+    // render). Only once a mixin / detached-ruleset call's output block
+    // (`mixinOutputSlot`) is in the chain do the inner declarations count as
+    // call-output — so `@import`ed call output is still caught, while plain
+    // nil-selector streaming stays unflagged.
+    if (isRoot && node.type === 'Rules') {
+      const slot = Boolean((node as { options?: { mixinOutputSlot?: unknown } }).options?.mixinOutputSlot);
+      checkValidNodes((node as { rules?: readonly Node[] }).rules, context, true, fromCallOutput || slot);
+      continue;
+    }
     if (node.type && !node.hasFlag(F_ALLOW_ROOT)) {
       throw makeJessError({
         code: 'eval/invalid-statement',

--- a/packages/css-parser/src/grammar.ts
+++ b/packages/css-parser/src/grammar.ts
@@ -249,7 +249,10 @@ export const cssGrammar = rules((g: any) => {
   const Quoted = node('Quoted', choice(singleStr, doubleStr));
   // bare number; the not()-lookahead is folded into the regex → one match, one leaf.
   const numTok = regex(/[+-]?(?:\d*\.\d+(?:[eE][+-]?\d+)?|\d+(?:[eE][+-]?\d+)?|\d+)(?![a-zA-Z\u0080-\uffff%])/);
-  const colorHex = regex(/#[0-9a-fA-F]{3,8}(?![0-9a-fA-F])/);
+  // Only the four valid hex-color lengths (3/4/6/8). Longest-first so a 5- or
+  // 7-digit run (`#fffff`) can't partial-match — the trailing lookahead then
+  // rejects it, making it a parse error (matches Less).
+  const colorHex = regex(/#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})(?![0-9a-fA-F])/);
   const Num = node('Num', numTok);
   const Color = node('Color', colorHex);
   const Paren = node('Paren', parser({ trivia: rw }, sequence(literal('('), g.parenBody)));

--- a/packages/less-parser/test/guards.test.ts
+++ b/packages/less-parser/test/guards.test.ts
@@ -140,7 +140,7 @@ describe('guardDefault', () => {
   it('evaluates parsed default() guards without using public Bool rendering', async () => {
     const { errors, tree } = parse(`
       .mixin() when (default()) { color: green; }
-      .mixin();
+      .a { .mixin(); }
     `, 'Stylesheet');
     const context = new Context();
     const originalToTrimmedString = Bool.prototype.toTrimmedString;
@@ -169,7 +169,7 @@ describe('guardDefault', () => {
       .mixin() when (default()) { color: green; }
       .mixin() { color: blue; }
       .mixin() when not (default()) { color: red; }
-      .mixin();
+      .a { .mixin(); }
     `, 'Stylesheet');
     const context = new Context();
     const originalToTrimmedString = Bool.prototype.toTrimmedString;
@@ -199,7 +199,7 @@ describe('guardDefault', () => {
     const { errors, tree } = parse(`
       .mixin() when (default()) { color: green; }
       .mixin() when not (default()) { color: red; }
-      .mixin();
+      .a { .mixin(); }
     `, 'Stylesheet');
     expect(errors.length).toBe(0);
     const context = new Context();


### PR DESCRIPTION
Back-ports the Less error-parity fixes landed on `feature/less-v5-alpha-readiness` to `dev` (per the "bug fixes on both branches" policy). Three localized checks that make Jess error where Less 4.x errors:

## 1. property-in-root
A property `Declaration` a mixin/detached-ruleset call drops at the **root** now errors ("Properties must be inside selector blocks"). `checkValidNodes` takes `isRoot` and recurses root-level `Rules` blocks; gated on `mixinOutputSlot` so nil-selector streaming isn't tripped, and `@import`ed call output IS caught. Also fixes 2 `guards.test` cases that called `.mixin();` at root (an actual property-in-root error) — wrapped in a selector.

## 2. detached-ruleset-on-property
`a: @dr;` / `a: @dr();` now errors ("Rulesets cannot be evaluated on a property"). `Declaration.evalNode` rejects a value that resolves to a detached ruleset (a `Mixin` uncalled, or `Rules` called). Scoped to regular property declarations; excludes value `Collection`s.

## 3. hex color length
`colorHex` narrowed to exactly 3/4/6/8-digit hex, so `#fffff` is a parse error.

## Coverage / gate
The alpha-side error-corpus lane is alpha-only; here these are covered by unit cases in `check-valid-nodes.test.ts` plus the existing suites. **core 2849/0, css-parser 188/0, less-parser at its 6-fail baseline.**