### PR TITLE
chore(deps): bump parseman ^0.16.0 → ^0.18.2

### DIFF
--- a/packages/css-parser/package.json
+++ b/packages/css-parser/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@jesscss/shared": "workspace:*",
-    "parseman": "^0.16.0",
+    "parseman": "^0.18.2",
     "@types/color-name": "^1.1.1",
     "@types/lodash-es": "~4.17.8",
     "@types/xregexp": "^4.4.0",

--- a/packages/jess-parser/package.json
+++ b/packages/jess-parser/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/color-name": "^1.1.1",
-    "parseman": "^0.16.0"
+    "parseman": "^0.18.2"
   },
   "type": "module",
   "module": "lib/index.js"

--- a/packages/less-parser/package.json
+++ b/packages/less-parser/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@jesscss/shared": "workspace:*",
     "less": "^4.6.3",
-    "parseman": "^0.16.0",
+    "parseman": "^0.18.2",
     "@types/node": "^18.19.31",
     "tsx": "~4.21.0"
   },

--- a/packages/scss-parser/package.json
+++ b/packages/scss-parser/package.json
@@ -39,7 +39,7 @@
     "chevrotain": "^12.0.0"
   },
   "devDependencies": {
-    "parseman": "^0.16.0",
+    "parseman": "^0.18.2",
     "sass-spec": "github:sass/sass-spec"
   },
   "author": "Matthew Dean <matthew-dean@users.noreply.github.com>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0
       parseman:
-        specifier: ^0.14.0
-        version: 0.14.0
+        specifier: ^0.18.2
+        version: 0.18.2
       tsx:
         specifier: ~4.21.0
         version: 4.21.0
@@ -444,8 +444,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.5
       parseman:
-        specifier: ^0.14.0
-        version: 0.14.0
+        specifier: ^0.18.2
+        version: 0.18.2
 
   packages/jess-plugin:
     dependencies:
@@ -617,8 +617,8 @@ importers:
         specifier: ^4.6.3
         version: 4.6.3
       parseman:
-        specifier: ^0.14.0
-        version: 0.14.0
+        specifier: ^0.18.2
+        version: 0.18.2
       tsx:
         specifier: ~4.21.0
         version: 4.21.0
@@ -654,8 +654,8 @@ importers:
         version: 12.0.0
     devDependencies:
       parseman:
-        specifier: ^0.14.0
-        version: 0.14.0
+        specifier: ^0.18.2
+        version: 0.18.2
       sass-spec:
         specifier: github:sass/sass-spec
         version: github.com/sass/sass-spec/f282e3844db9889a0747b810898f67571272e8e5(@babel/core@7.28.6)
@@ -7329,7 +7329,7 @@ packages:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      vite: 6.4.1(@types/node@20.19.30)(less@4.6.3)
+      vite: 6.4.1(@types/node@22.19.7)(less@4.6.3)
     dev: true
 
   /@vitest/mocker@4.1.2(vite@6.4.1):
@@ -16863,8 +16863,8 @@ packages:
     dependencies:
       entities: 6.0.1
 
-  /parseman@0.14.0:
-    resolution: {integrity: sha512-FHwJzhr+wAOSoA3kBkeaYVK8s3pFcIJFu/pKKPUp4aXUxA/M0cgmrRCoRQml7YqEIt18EYEhBi6GGhYOOA5Gtw==}
+  /parseman@0.18.2:
+    resolution: {integrity: sha512-PEloFH7ZrqvmcKs9bDG51niYRLpLcn1sqcG50g9fViEF6Z+X6z/g8ojUQ/6j72577cqakpAg5bQIuFHl4ghgZA==}
     dependencies:
       magic-string: 0.30.21
       oxc-parser: 0.137.0


### PR DESCRIPTION
Adopts published **parseman 0.18.2** in the parser packages, mirroring the same bump on `feature/less-v5-alpha-readiness`.

## What changed
- `css-parser`, `less-parser`, `scss-parser`, `jess-parser`: `parseman` `^0.16.0` → `^0.18.2`
- `pnpm-lock.yaml`: regenerated via a **surgical `pnpm install`** — parseman-only diff (11 lines), no unrelated transitive churn.

## Why 0.18.2
Brings the 0.17.0 size-reduction line (less-parser 5.30→1.07 MB) plus 0.18 `token()`, `expect()` label derivation, and the interpreter hot-path pass. dev uses no removed 0.18 APIs (`staticExpected` absent).

## Verification
- `@jesscss/css-parser`: **188/188** pass on 0.18.2.
- CI is the full gate here for the rest of the dev suite.