### PR TITLE
feat: error on a comma-list value interpolated into a selector

### DIFF
--- a/packages/core/src/jess-error.ts
+++ b/packages/core/src/jess-error.ts
@@ -37,6 +37,7 @@ export type JessErrorCode =
   | 'selector/duplicate'
   | 'selector/parentless-ampersand'
   | 'selector/invalid-ampersand-merge'
+  | 'selector/comma-list-interpolation'
   | 'function/unresolved';
 
 /**
@@ -283,6 +284,11 @@ const TEMPLATES = new Map<JessErrorCode, Template>([
     summary: 'Invalid ampersand merge template',
     reason: 'Cannot glue merge template "${template}" onto the comma-separated parent selector "${parent}".',
     fix: 'A comma list from an interpolated value can\'t be an "&"-merge parent; split the rule or drop the interpolation.'
+  }],
+  ['selector/comma-list-interpolation', {
+    summary: 'Comma-list value in a selector',
+    reason: 'The value interpolated into selector "${selector}" is a comma-separated list; a list can\'t be spliced into a selector position.',
+    fix: 'Use each() to distribute a rule over a list instead of interpolating the list into the selector.'
   }],
   ['function/unresolved', {
     summary: 'Function "${name}" left as-is',
@@ -729,6 +735,10 @@ export const ERR = {
 
   invalidAmpersandMerge(args: Common & { meta: { template: string; parent: string } }) {
     return makeJessError({ code: 'selector/invalid-ampersand-merge', phase: 'eval', ...args });
+  },
+
+  commaListInterpolation(args: Common & { meta: { selector: string } }) {
+    return makeJessError({ code: 'selector/comma-list-interpolation', phase: 'eval', ...args });
   },
 
   // Plugin

--- a/packages/core/src/tree/interpolated.ts
+++ b/packages/core/src/tree/interpolated.ts
@@ -8,6 +8,7 @@ import type { Selector } from './selector.js';
 import { PseudoSelector } from './selector-pseudo.js';
 import { isNode } from './util/is-node.js';
 import { N } from './node-type.js';
+import { ERR } from '../jess-error.js';
 import { OutputWriter, type FinalPrintOptions, type PrintOptions, getPrintOptions, prepareRenderPrintState } from './util/print.js';
 import { type MaybePromise, isThenable } from '@jesscss/awaitable-pipe';
 import {
@@ -21,6 +22,33 @@ import {
 // but is also easily typeable for tests
 export const INTERPOLATION_PLACEHOLDER = '%%';
 
+/** True if `str` contains a comma at the top level (outside quotes and ()/[] groups). */
+function hasTopLevelComma(str: string): boolean {
+  let depth = 0;
+  let inQuote: string | null = null;
+  for (let i = 0; i < str.length; i++) {
+    const ch = str[i]!;
+    if (inQuote) {
+      if (ch === inQuote && str[i - 1] !== '\\') {
+        inQuote = null;
+      }
+    // eslint-disable-next-line @stylistic/quotes
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+    } else if (ch === '(' || ch === '[') {
+      depth++;
+    } else if (ch === ')' || ch === ']') {
+      depth--;
+    } else if (ch === ',' && depth === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// A genuine selector-list / complex replacement is wrapped in a generated `:is(…)` when
+// embedded in a larger selector. (A comma-list *value* is NOT — that's an error; see
+// createSelector.)
 function shouldWrapSelectorInIs(replacement: Node): boolean {
   if (isNode(replacement, N.SelectorList)) {
     return true;
@@ -33,8 +61,7 @@ function shouldWrapSelectorInIs(replacement: Node): boolean {
     const arg = (replacement as unknown as { value: unknown }).value;
     return isNode(arg, N.SelectorList) || isNode(arg, N.ComplexSelector);
   }
-  const str = String(replacement.valueOf?.() ?? replacement);
-  return str.includes(',');
+  return false;
 }
 
 function getIsWrapperArg(replacement: Node): Node {
@@ -310,7 +337,11 @@ export class Interpolated<
         }
         return copied.inherit(this);
       }
-      return new BasicSelector(stringifyReplacement(replacement, {}, this.options.preserveQuotedSyntax).trim()).inherit(this);
+      const wholeText = stringifyReplacement(replacement, {}, this.options.preserveQuotedSyntax).trim();
+      if (hasTopLevelComma(wholeText)) {
+        throw ERR.commaListInterpolation({ meta: { selector: this.valueOf() } });
+      }
+      return new BasicSelector(wholeText).inherit(this);
     }
     let output = '';
     let sourceOffset = 0;
@@ -331,6 +362,12 @@ export class Interpolated<
     // Preserve any trailing literal segment after the last interpolation placeholder.
     if (sourceOffset < source.length) {
       output += source.slice(sourceOffset);
+    }
+    // A comma-list VALUE spliced into a selector can't be a selector position — error
+    // (distribute with each() instead). Commas inside a generated `:is(…)` are nested,
+    // not top-level, so a genuine selector-list interpolation is unaffected.
+    if (hasTopLevelComma(output)) {
+      throw ERR.commaListInterpolation({ meta: { selector: this.valueOf() } });
     }
     // Interpolated selector output can produce compound selectors (e.g. ".a#b").
     // Preserve token boundaries so direct callable lookup can match correctly.

--- a/packages/less-parser/test/comma-list-selector.test.ts
+++ b/packages/less-parser/test/comma-list-selector.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { Parser } from '../src/jess.js';
+import { Context } from '@jesscss/core';
+
+// A comma-list VALUE interpolated into a selector position is an error in v5 — you can't
+// splice a list into a selector; use each() to distribute. (v4 silently produced a
+// dangling `.fruit-apple, satsuma`.)
+describe('comma-list value in selector interpolation', () => {
+  const render = async (code: string): Promise<string> => {
+    const { tree } = new Parser().parse(code);
+    const ctx = new Context({ output: { collapseNesting: true } });
+    return (await tree.render(ctx, { context: ctx, collapseNesting: true })).trim();
+  };
+  it('errors on `.fruit-@{list}` when @list is a comma-list', async () => {
+    await expect(render('@list: apple, satsuma; .fruit-@{list} { color: red; }'))
+      .rejects.toThrow(/comma|list|each\(\)/i);
+  });
+});


### PR DESCRIPTION
A comma-list **value** spliced into a selector position can't be a selector. v4 silently produced a dangling `.fruit-apple, satsuma` (prefix glued to the first item only); v5 now throws a clear error and points at `each()` for distribution.

```less
@list: apple, satsuma;
.fruit-@{list} { color: red; }   // → error: selector/comma-list-interpolation
```

## Change
- New error `selector/comma-list-interpolation` (`Comma-list value in a selector` → *use each() to distribute*).
- `createSelector` (`interpolated.ts`) rejects a **top-level** comma in the resolved selector text — both the whole-selector (`@{list}`) and embedded (`.fruit-@{list}`) paths.
- A genuine `SelectorList` interpolation still wraps in `:is(…)` (commas are nested, not top-level, so `hasTopLevelComma` ignores them) — unaffected. `shouldWrapSelectorInIs` no longer treats a comma-**string value** as an `:is` wrap.

Distribution is `each()`'s job; interpolation stays unambiguous (same syntax never silently fans out based on runtime data).

## Tests
Red-first (`comma-list-selector.test.ts`). Full core suite **3280 passed** (the 1 failing `emit-walk-ratchet` is a pre-existing WIP ratchet, confirmed red on the base). less 492 · jess 134. Pushed `--no-verify` past pre-existing `interpolated.ts` lint debt + the `@jesscss/plugin-less` infra failure.