### PR TITLE
fix: Node API for ESM file URL to path

### DIFF
--- a/vitest.less-test-data.config.ts
+++ b/vitest.less-test-data.config.ts
@@ -1,10 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { builtinModules } from 'node:module';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 import parseman from 'parseman/plugin';
 
-const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname));
+const repoRoot = path.dirname(fileURLToPath(import.meta.url));
 const packagesRoot = path.join(repoRoot, 'packages');
 const sharedNodeModules = fs.realpathSync(path.join(repoRoot, 'node_modules'));
 const sharedRepoRoot = path.dirname(sharedNodeModules);


### PR DESCRIPTION
* Use Node API for ESM file URL to native filesystem path to better support Windows hosts.

**Why**

Some test commands may fail on Windows without the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test configuration path handling for more reliable execution across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->