### PR TITLE
chore(deps): bump parseman to 0.50.1 (fixes vitest slowdown)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint-staged": "13.2.1",
     "lite-server": "^2.6.1",
     "normalize.css": "^8.0.1",
-    "parseman": "^0.50.0",
+    "parseman": "^0.50.1",
     "puppeteer": "^19.10.1",
     "rollup": "^3.20.7",
     "shx": "^0.3.4",

--- a/packages/parser-shared/package.json
+++ b/packages/parser-shared/package.json
@@ -34,10 +34,10 @@
     "compile": "tsdown --tsconfig tsconfig.build.json --no-dts && tsc -p tsconfig.build.json --emitDeclarationOnly"
   },
   "peerDependencies": {
-    "parseman": "^0.50.0"
+    "parseman": "^0.50.1"
   },
   "devDependencies": {
-    "parseman": "^0.50.0",
+    "parseman": "^0.50.1",
     "tsdown": "~0.21.7"
   },
   "author": "Matthew Dean <matthew-dean@users.noreply.github.com>",

--- a/packages/syntax/css/css-parser/package.json
+++ b/packages/syntax/css/css-parser/package.json
@@ -90,7 +90,7 @@
   },
   "peerDependencies": {
     "@jesscss/core": "workspace:*",
-    "parseman": "^0.50.0"
+    "parseman": "^0.50.1"
   },
   "peerDependenciesMeta": {
     "@jesscss/core": {
@@ -100,7 +100,7 @@
   "devDependencies": {
     "@jesscss/core": "workspace:*",
     "@jesscss/shared": "workspace:*",
-    "parseman": "^0.50.0",
+    "parseman": "^0.50.1",
     "postcss": "8.5.23",
     "tsx": "~4.21.0"
   },

--- a/packages/syntax/jess/jess-parser/package.json
+++ b/packages/syntax/jess/jess-parser/package.json
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@jesscss/core": "workspace:*",
-    "parseman": "^0.50.0"
+    "parseman": "^0.50.1"
   },
   "peerDependenciesMeta": {
     "@jesscss/core": {
@@ -90,7 +90,7 @@
     "@jesscss/core": "workspace:*",
     "@jesscss/parser-shared": "workspace:*",
     "@types/color-name": "^1.1.1",
-    "parseman": "^0.50.0"
+    "parseman": "^0.50.1"
   },
   "type": "module",
   "module": "lib/index.js"

--- a/packages/syntax/less/less-parser/package.json
+++ b/packages/syntax/less/less-parser/package.json
@@ -81,7 +81,7 @@
   },
   "peerDependencies": {
     "@jesscss/core": "workspace:*",
-    "parseman": "^0.50.0"
+    "parseman": "^0.50.1"
   },
   "peerDependenciesMeta": {
     "@jesscss/core": {
@@ -94,7 +94,7 @@
     "@jesscss/shared": "workspace:*",
     "@types/node": "^18.19.31",
     "less": "^4.6.3",
-    "parseman": "^0.50.0",
+    "parseman": "^0.50.1",
     "postcss-less": "~6.0.0",
     "tsx": "~4.21.0"
   },

--- a/packages/syntax/scss/scss-parser/package.json
+++ b/packages/syntax/scss/scss-parser/package.json
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@jesscss/core": "workspace:*",
-    "parseman": "^0.50.0"
+    "parseman": "^0.50.1"
   },
   "peerDependenciesMeta": {
     "@jesscss/core": {
@@ -88,7 +88,7 @@
   "devDependencies": {
     "@jesscss/core": "workspace:*",
     "@jesscss/parser-shared": "workspace:*",
-    "parseman": "^0.50.0",
+    "parseman": "^0.50.1",
     "sass-spec": "github:sass/sass-spec"
   },
   "author": "Matthew Dean <matthew-dean@users.noreply.github.com>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1
       parseman:
-        specifier: ^0.50.0
-        version: 0.50.0
+        specifier: ^0.50.1
+        version: 0.50.1
       puppeteer:
         specifier: ^19.10.1
         version: 19.11.1(typescript@7.0.1-rc)
@@ -726,8 +726,8 @@ importers:
   packages/parser-shared:
     devDependencies:
       parseman:
-        specifier: ^0.50.0
-        version: 0.50.0
+        specifier: ^0.50.1
+        version: 0.50.1
       tsdown:
         specifier: ~0.21.7
         version: 0.21.7(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(typescript@7.0.1-rc)
@@ -769,8 +769,8 @@ importers:
         specifier: workspace:*
         version: link:../../../_shared
       parseman:
-        specifier: ^0.50.0
-        version: 0.50.0
+        specifier: ^0.50.1
+        version: 0.50.1
       postcss:
         specifier: 8.5.23
         version: 8.5.23
@@ -797,8 +797,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.5
       parseman:
-        specifier: ^0.50.0
-        version: 0.50.0
+        specifier: ^0.50.1
+        version: 0.50.1
 
   packages/syntax/jess/jess-plugin-jess:
     dependencies:
@@ -880,8 +880,8 @@ importers:
         specifier: ^4.6.3
         version: 4.6.3
       parseman:
-        specifier: ^0.50.0
-        version: 0.50.0
+        specifier: ^0.50.1
+        version: 0.50.1
       postcss-less:
         specifier: ~6.0.0
         version: 6.0.0(postcss@8.5.23)
@@ -917,8 +917,8 @@ importers:
         specifier: workspace:*
         version: link:../../../parser-shared
       parseman:
-        specifier: ^0.50.0
-        version: 0.50.0
+        specifier: ^0.50.1
+        version: 0.50.1
       sass-spec:
         specifier: github:sass/sass-spec
         version: github.com/sass/sass-spec/67c3b83a26fd3f9772dd0d3e318fe32aefb38eef(@babel/core@7.29.7)(eslint@9.39.2)
@@ -18509,8 +18509,8 @@ packages:
     dependencies:
       entities: 6.0.1
 
-  /parseman@0.50.0:
-    resolution: {integrity: sha512-1o+MQCZ9Kvo570tHD72/TDSzeAMT/JCmvOpeIAm+ArMTu6PB3v/t3UgEiJ4W02+eNvKg/8A2os00KB2kSaGXng==}
+  /parseman@0.50.1:
+    resolution: {integrity: sha512-/mFlajA51zmT6Si3t5mYhzjPTEPRoNBhH9TEdFPX6synrdcZNJQPfi/XogdDs6Fy9OI8OjttzPiUn9xjrsxYEQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
     dependencies:


### PR DESCRIPTION
Bumps `parseman` `^0.50.0` → `^0.50.1` (published, live on npm).

0.50.1 fixes the dev-time vitest-transform regression 0.50.0 introduced (the `hasSideWriter` memo was rebuilt per call → O(sites × graph) on the composed grammars). Emitted artifacts are **byte-identical to 0.50.0** — build/dev-time speed only.

## Verified
- `pnpm run build:release` — clean, all packages macro-buildable on 0.50.1
- Vitest speed restored: `test/less/merge-fallback-contract.test.ts` = **14.3s** on 0.50.1 vs **58–65s** on broken 0.50.0 (0.49.0 was ~10s)
- Minimal, parseman-only lockfile change (11 pins → `^0.50.1`; 28 lockfile lines, all parseman)