### PR TITLE
fix(plugin-less): map strictUnits:false to unitMode 'loose'

### DIFF
--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -177,7 +177,7 @@ export interface LessOptions {
 
   /**
    * @deprecated Use `unitMode` instead. If `true`, sets `unitMode` to 'strict'.
-   * If `false`, sets the unitMode to 'loose.
+   * If `false`, sets the unitMode to 'loose'.
    * If undefined, uses the `unitMode` value (defaults to 'preserve').
    * @default false
    */

--- a/packages/syntax/less/jess-plugin-less/src/index.ts
+++ b/packages/syntax/less/jess-plugin-less/src/index.ts
@@ -320,6 +320,8 @@ export class LessPlugin extends AbstractPlugin {
       unitMode = opts.unitMode;
     } else if (opts.strictUnits === true) {
       unitMode = 'strict';
+    } else if (opts.strictUnits === false) {
+      unitMode = 'loose';
     } else {
       unitMode = lessPluginDefaults.unitMode;
     }


### PR DESCRIPTION
## What

The Less-compat option normalizer in `@jesscss/plugin-less` handled `strictUnits:true → 'strict'` but **dropped `strictUnits:false`**, so it fell through to the `preserve` default. A `.less` file (or fixture `styles.config`) asking for loose 4.x-style unit behavior silently got `preserve` (composed `calc()`) instead.

## Fix

One branch in [`jess-plugin-less/src/index.ts`](https://github.com/jesscss/jess/blob/fix/less-strictunits-false-loose/packages/syntax/less/jess-plugin-less/src/index.ts) so the full ladder holds:

| Less option | `unitMode` |
|---|---|
| `strictUnits: false` | `loose` (4.x answer + `eval/unexpressible-unit` warning) |
| *unset* | `preserve` (composed `calc()` + warning) |
| `strictUnits: true` | `strict` (throws) |

Plus a doc-comment typo fix in `@jesscss/config` types.

## Tests
All unit-mode suites green: all-less unit 82/82, config 31/31, `strict-units.test.ts` 4/4, unit-mode cluster 68/68, plugin-less 14/14, core compare 18/18.

Paired corpus correction (`no-strict.css` → loose) lands in the Less `@less/test-data` alpha.

> Note: the `less-alpha-readiness` CI job is red on the pre-existing corpus-resolution issue (`@less/test-data` not provisioned in CI), tracked separately — not caused by this change.