### PR TITLE
fix(ci): check out Less.js corpus for the pr-quality-gate

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -30,9 +30,23 @@ jobs:
   pr-quality-gate:
     name: Full build, lint, tests & structural gates
     runs-on: ubuntu-latest
+    # Corpus-backed jess tests (test/less/*.test.ts via resolveLessTestDataRoot)
+    # run inside `pnpm ci`. They resolve the @less/test-data corpus, which is a
+    # sibling `link:../less.js/packages/test-data` checkout absent in CI; without
+    # it those files fail to load (dropping ~250 collected tests) and their cases
+    # fail. Point every step at the corpus we check out below.
+    env:
+      LESS_TEST_DATA_ROOT: ${{ github.workspace }}/less-corpus/packages/test-data
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Checkout Less.js corpus (matthew-dean/less.js@alpha)
+        uses: actions/checkout@v4
+        with:
+          repository: matthew-dean/less.js
+          ref: alpha
+          path: less-corpus
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/scripts/verify-node-copy-frontier.mjs
+++ b/scripts/verify-node-copy-frontier.mjs
@@ -111,7 +111,7 @@ function isCommentLine(line) {
 }
 
 function isBitSetCloneLine(relativeFile, line) {
-  return relativeFile === 'packages/core/src/tree/util/bitset.ts'
+  return relativeFile === 'packages/core/src/util/bitset.ts'
     || /\.keySet\.clone\(\)/u.test(line)
     || /\.visibleKeySet\.clone\(\)/u.test(line)
     || /\.requiredKeySet\.clone\(\)/u.test(line)


### PR DESCRIPTION
The gate's `pnpm ci` runs corpus-backed jess tests (namespaced-mixin-value, operations-placement, strict-units, …) that resolve `@less/test-data` via `resolveLessTestDataRoot`. The corpus (`link:../less.js/packages/test-data`) isn't checked out in CI, so those files fail to load (~250 fewer collected tests) and show as unexplained 'new failures'. Checks out `matthew-dean/less.js@alpha` + sets `LESS_TEST_DATA_ROOT`, mirroring #102. This is the real cause of the remaining Full-build reds.