### PR TITLE
grammar(css): Stage B — factor simpleSelectorAtom/calcValueAtom/valueAtom leaves

### DIFF
--- a/docs/design/GRAMMAR-REBUILD-SPEC.md
+++ b/docs/design/GRAMMAR-REBUILD-SPEC.md
@@ -75,6 +75,15 @@ Four consequences, none of them optional:
 
 ### 0.2 Current status
 
+> **CORRECTION BANNER (2026-08-29).** The version and blocker facts in this
+> section are **stale**. parseman is now **0.50.1** (not 0.47.1), and the
+> compose / hard-rule-2 blocker that §5.x/§6 describe as open was **lifted in
+> 0.49.0**. The live method of record for the lean-grammar / compose phase is
+> **`docs/design/COMPOSE-MIGRATION-SPEC.md`** (Stages A–D), **not** §5.x/§6 of
+> this document. Read that spec first for anything touching grammar compose or
+> the css leaf-factoring; treat the rest of §0 below as historical planning
+> evidence.
+
 **The parseman floor is paid.** parseman resolves to **0.47.1** from the registry
 (`pnpm-lock.yaml`, sole entry); the root, `@jesscss/parser-shared`, and all four
 parser packages depend on `^0.47.1` (after `ff685793a` took the floor to `^0.46.0`,

--- a/packages/syntax/css/css-parser/src/grammar.ts
+++ b/packages/syntax/css/css-parser/src/grammar.ts
@@ -276,6 +276,9 @@ type GrammarRuleName =
   | 'descriptorBodyBlock'
   | 'declarationListItem'
   | 'declarationListDeclaration'
+  | 'simpleSelectorAtom'
+  | 'calcValueAtom'
+  | 'valueAtom'
   | 'RoutedAtRuleStatement'
   | 'pseudoArgumentContent'
   | 'CustomPropertyValue'
@@ -1121,22 +1124,35 @@ const cssFactory = (g: GrammarSelf) => {
     literal('&'),
     () => simpleSelector('&')
   );
+
+  /*
+   * The simple-selector atom shared by the compound towers. `&`
+   * (NestingSelector) is NOT an arm here: a nested `&` is valid inside
+   * `CompoundSelector` but a top-level compound never begins with one, so
+   * `TopLevelCompoundSelector` inherits this atom as-is while `CompoundSelector`
+   * adds the `&` arm on top. A superset widens this one leaf (interpolation,
+   * placeholder, etc.) and inherits the whole selector tower via open-recursion
+   * (COMPOSE-MIGRATION-SPEC.md §4.1).
+   */
+  const simpleSelectorAtom = choice(
+    parser(
+      { trivia: interstitialTrivia },
+      g.AttributeSelector
+    ),
+    parser(
+      { trivia: interstitialTrivia },
+      g.PseudoSelector
+    ),
+    g.NamespaceTypeSelector,
+    g.BasicSelector
+  );
   const CompoundSelector = node(
     'CompoundSelector',
     noTrivia(parser(
       { trivia: compoundTrivia },
       oneOrMore(choice(
         g.NestingSelector,
-        parser(
-          { trivia: interstitialTrivia },
-          g.AttributeSelector
-        ),
-        parser(
-          { trivia: interstitialTrivia },
-          g.PseudoSelector
-        ),
-        g.NamespaceTypeSelector,
-        g.BasicSelector
+        g.simpleSelectorAtom
       ))
     )),
     children => selectorTermFromTokens(children.filter(isSimpleToken))
@@ -1145,18 +1161,7 @@ const cssFactory = (g: GrammarSelf) => {
     'TopLevelCompoundSelector',
     noTrivia(parser(
       { trivia: compoundTrivia },
-      oneOrMore(choice(
-        parser(
-          { trivia: interstitialTrivia },
-          g.AttributeSelector
-        ),
-        parser(
-          { trivia: interstitialTrivia },
-          g.PseudoSelector
-        ),
-        g.NamespaceTypeSelector,
-        g.BasicSelector
-      ))
+      oneOrMore(g.simpleSelectorAtom)
     )),
     children => selectorTermFromTokens(children.filter(isSimpleToken))
   );
@@ -1749,18 +1754,19 @@ const cssFactory = (g: GrammarSelf) => {
    * creates through the value dispatch is not inert. `CalcParen` already covers
    * the arithmetic-grouping shape, which is the one css-values-4 §10 defines.
    */
+  const calcValueAtom = choice(
+    g.Percentage,
+    g.Dimension,
+    g.Color,
+    g.UnicodeRange,
+    g.CalcIdentOrFunction,
+    g.CalcParen,
+    g.Quoted,
+    g.CustomPropertyValue
+  );
   const CalcValue = node(
     'CalcValue',
-    choice(
-      g.Percentage,
-      g.Dimension,
-      g.Color,
-      g.UnicodeRange,
-      g.CalcIdentOrFunction,
-      g.CalcParen,
-      g.Quoted,
-      g.CustomPropertyValue
-    ),
+    g.calcValueAtom,
     { project: 0 }
   );
   const CalcProduct = node(
@@ -2232,31 +2238,32 @@ const cssFactory = (g: GrammarSelf) => {
   );
   const CalcIdentOrFunction = typedIdentOrFunction;
   const TypedIdentOrFunction = typedIdentOrFunction;
+
+  /*
+   * Identifier-shaped atoms are routed by `IdentOrFunction`: known glued
+   * functions keep their dedicated tails, other glued functions use the
+   * generic call tail, and an identifier with no glued `(` is either the
+   * spaced paren bridge (`foo (bar)`, which preserves its authored separator
+   * as a value boundary) or a keyword. One route means the identifier is
+   * scanned once. The final punctuation fallback needs no negative identifier
+   * preflight: every identifier-shaped start has already been consumed by
+   * this route.
+   */
+  const valueAtom = choice(
+    g.Percentage,
+    g.Dimension,
+    g.Color,
+    g.UnicodeRange,
+    IdentOrFunction,
+    g.ParenValue,
+    g.SquareValue,
+    g.Quoted,
+    g.CustomPropertyValue,
+    g.PunctuationValue
+  );
   const Value = node(
     'Value',
-
-    /*
-     * Identifier-shaped atoms are routed by `IdentOrFunction`: known glued
-     * functions keep their dedicated tails, other glued functions use the
-     * generic call tail, and an identifier with no glued `(` is either the
-     * spaced paren bridge (`foo (bar)`, which preserves its authored separator
-     * as a value boundary) or a keyword. One route means the identifier is
-     * scanned once. The final punctuation fallback needs no negative identifier
-     * preflight: every identifier-shaped start has already been consumed by
-     * this route.
-     */
-    choice(
-      g.Percentage,
-      g.Dimension,
-      g.Color,
-      g.UnicodeRange,
-      IdentOrFunction,
-      g.ParenValue,
-      g.SquareValue,
-      g.Quoted,
-      g.CustomPropertyValue,
-      g.PunctuationValue
-    ),
+    g.valueAtom,
     { project: 0 }
   );
   const ValueSequence = node(
@@ -3757,6 +3764,7 @@ const cssFactory = (g: GrammarSelf) => {
     TopLevelComplexSelector,
     CompoundSelector,
     TopLevelCompoundSelector,
+    simpleSelectorAtom,
     BasicSelector,
     NamespaceTypeSelector,
     AttributeSelector,
@@ -3800,12 +3808,14 @@ const cssFactory = (g: GrammarSelf) => {
     PunctuationValue,
     ValueSequence,
     ValueList,
+    calcValueAtom,
     CalcValue,
     CalcProduct,
     CalcSum,
     CalcSequence,
     calcFunctionArguments,
     MathFunction,
+    valueAtom,
     Value,
     TypedValue,
     TypedValueSequence,


### PR DESCRIPTION
COMPOSE-MIGRATION-SPEC §4.1/§7 Stage B, CSS side. Extracts three named leaf rules (`simpleSelectorAtom` excl. `&`, `calcValueAtom`, `valueAtom`) so dialect supersets can widen one leaf and inherit the tower via open-recursion, instead of re-listing base arms. Behavior-neutral: css byte-identity oracle 63/63 identical, 6/6 tests pass; `check:macro` 0 fallbacks; types+lint clean on grammar.ts. Also corrects the stale parseman-version/compose-blocked facts in GRAMMAR-REBUILD-SPEC §0.2. Prereq for Stage C (dialects composing on cssBaseRules).