### PR TITLE
fix(core): remove duplicate unreachable 'Sequence' case

### DIFF
--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -2365,8 +2365,6 @@ function callValueContainsVarRef(value: CallValue, name: string, lookup: 'live' 
       return value.parts.some(part => callValueContainsVarRef(part, name, lookup));
     case 'List':
       return value.value.some(part => callValueContainsVarRef(part, name, lookup));
-    case 'Sequence':
-      return value.parts.some(part => callValueContainsVarRef(part, name, lookup));
     case 'Important':
       return callValueContainsVarRef(value.value, name, lookup);
     case 'Operation':


### PR DESCRIPTION
Vite (SSR) flagged a duplicate case clause in `callValueContainsVarRef` (`packages/core/src/ast/serialize.ts`): two identical `case 'Sequence':` arms straddling `case 'List':`. The second is unreachable dead code.

Verified behavior-neutral: only `Sequence` and `Interpolation` own a `.parts` field (nodes.ts:151, :392) and both are already handled (Interpolation has its own arm), so the duplicate was a pure copy-paste, not a mistyped stand-in for an unhandled type. Removed the dead arm; the first `case 'Sequence':` still handles it.