### PR TITLE
fix(release): front-load npm publish auth before the preflight

### DIFF
--- a/scripts/release/publish-alpha.mjs
+++ b/scripts/release/publish-alpha.mjs
@@ -6,6 +6,7 @@ import {
   applyLockstepVersion,
   compareSemver,
   computeMinAlphaTag,
+  ensurePublishAuth,
   getAlphaReleasePlan,
   isAlphaClobber,
   resolveAlphaPublishVersion
@@ -179,16 +180,14 @@ function setLatestTag(pkgName, version, dryRun) {
 }
 
 function assertNpmAuth() {
-  const result = spawnSync('npm', ['whoami'], {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    shell: process.platform === 'win32'
-  });
-  if (result.status !== 0) {
-    console.error('\nnpm is not authenticated. Run `npm login` to sign in, then retry.');
-    console.error('For CI, set NPM_TOKEN in the environment.\n');
-    process.exit(1);
-  }
+  /*
+   * Front-load publish auth (browser login when the account gates writes behind
+   * 2FA that `npm whoami` can't see). No-ops when release-alpha already verified
+   * it this run (via the inherited __ALPHA_AUTH_VERIFIED flag), so a standalone
+   * `release:alpha:publish` still prompts up front but the orchestrated path does
+   * not double-prompt.
+   */
+  ensurePublishAuth();
 }
 
 const options = parseArgs(process.argv);

--- a/scripts/release/release-alpha.mjs
+++ b/scripts/release/release-alpha.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import {
   applyLockstepVersion,
+  ensurePublishAuth,
   getAlphaReleasePlan,
   isReleaseArtifactPath,
   resolveAlphaPublishVersion
@@ -252,22 +253,14 @@ if (branch !== 'alpha' && options.dryRun) {
 }
 
 if (!options.dryRun) {
-  // Check npm auth early so we don't waste time on checks/versioning only to fail at publish
-  const whoami = spawnSync('npm', ['whoami'], {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    shell: process.platform === 'win32'
-  });
-  if (whoami.status !== 0) {
-    console.log('\nnpm is not authenticated. Running `npm login`...\n');
-    const login = spawnSync('npm', ['login'], {
-      stdio: 'inherit',
-      shell: process.platform === 'win32'
-    });
-    if (login.status !== 0) {
-      throw new Error('npm login failed. Cannot publish without authentication.');
-    }
-  }
+  /*
+   * Front-load publish auth BEFORE the long preflight, so a 2FA/login prompt lands
+   * at minute 0, not after the whole build+check suite. `npm whoami` alone is not
+   * enough — see ensurePublishAuth. Mark it verified so the child publish-alpha
+   * (spawned below) inherits the flag and does not prompt a second time.
+   */
+  ensurePublishAuth();
+  process.env.__ALPHA_AUTH_VERIFIED = '1';
   assertReadyWorkingTree(rootDir);
 }
 

--- a/scripts/release/release-utils.mjs
+++ b/scripts/release/release-utils.mjs
@@ -676,3 +676,68 @@ export function getAlphaReleasePlan({
     errors
   };
 }
+
+/**
+ * Front-load npm publish-readiness so a 2FA prompt never lands AFTER the long
+ * preflight. `npm whoami` proves only READ auth: it needs no OTP, so it succeeds
+ * with a token that — under `two-factor auth: auth-and-writes` — still cannot
+ * complete a `npm publish` non-interactively. A multi-package release would then
+ * greenlight, run the whole preflight, and only THEN stall on the first publish's
+ * OTP. So when the account gates writes behind 2FA we refresh the login (browser)
+ * UP FRONT. An automation token (NPM_TOKEN) bypasses 2FA, so we skip the refresh
+ * when one is set. Idempotent within a release: release-alpha sets
+ * `__ALPHA_AUTH_VERIFIED` before spawning publish-alpha, which the child inherits.
+ */
+export function ensurePublishAuth() {
+  if (process.env.__ALPHA_AUTH_VERIFIED === '1') {
+    return;
+  }
+  const useShell = process.platform === 'win32';
+  const whoami = spawnSync('npm', ['whoami'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: useShell
+  });
+  const loggedIn = whoami.status === 0;
+  const user = loggedIn ? whoami.stdout.trim() : null;
+  let needLogin = !loggedIn;
+
+  /*
+   * A valid `whoami` is NOT proof of publish-readiness. Under 2FA-on-writes every
+   * `npm publish` needs a fresh OTP that `whoami` never asked for; an automation
+   * token bypasses 2FA. So if we hold a token but the account gates writes behind
+   * 2FA, refresh the session now rather than discovering it post-preflight.
+   */
+  if (loggedIn && !process.env.NPM_TOKEN) {
+    const profile = spawnSync('npm', ['profile', 'get'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: useShell
+    });
+    const twoFactorWrites = profile.status === 0
+      && /two-factor auth:\s*auth-and-writes/i.test(profile.stdout);
+    if (twoFactorWrites) {
+      console.log(`\nnpm reports you as '${user}', but this account gates every publish behind 2FA`);
+      console.log('(two-factor auth: auth-and-writes), which `npm whoami` cannot see. A multi-package');
+      console.log('release cannot clear that non-interactively, so refreshing your npm login now');
+      console.log('(browser) — UP FRONT, before the preflight — so the publish does not stall 15+');
+      console.log('minutes in. To publish non-interactively instead, use an automation token that');
+      console.log('bypasses 2FA (set NPM_TOKEN).\n');
+      needLogin = true;
+    }
+  }
+
+  if (needLogin) {
+    if (!loggedIn) {
+      console.log('\nnpm is not authenticated. Opening browser login...\n');
+    }
+    const login = spawnSync('npm', ['login', '--auth-type=web'], {
+      stdio: 'inherit',
+      shell: useShell
+    });
+    if (login.status !== 0) {
+      throw new Error('npm login failed. Cannot publish without authentication.');
+    }
+  }
+  process.env.__ALPHA_AUTH_VERIFIED = '1';
+}

--- a/scripts/release/ship-alpha-no-checks.mjs
+++ b/scripts/release/ship-alpha-no-checks.mjs
@@ -11,7 +11,7 @@
  */
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
-import { getAlphaPublishStatus, getAlphaReleasePlan, incrementAlphaVersions } from './release-utils.mjs';
+import { ensurePublishAuth, getAlphaPublishStatus, getAlphaReleasePlan, incrementAlphaVersions } from './release-utils.mjs';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -117,13 +117,13 @@ if (branch !== 'alpha' && !DRY_RUN) {
   process.exit(1);
 }
 
-// Auth check (skip for dry-run)
+/*
+ * Front-load publish auth up front (skip for dry-run). See ensurePublishAuth:
+ * `npm whoami` can't see a 2FA-on-writes gate, so refresh the login now, not at
+ * the first publish.
+ */
 if (!DRY_RUN) {
-  const whoami = spawnSync('npm', ['whoami'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], shell: true });
-  if (whoami.status !== 0) {
-    console.error('\nnpm is not authenticated. Run `npm login` first.');
-    process.exit(1);
-  }
+  ensurePublishAuth();
 }
 
 /*


### PR DESCRIPTION
**Problem:** publishing an alpha runs ~18 min of preflight, then fails at the first `npm publish` with a 2FA prompt — because the early auth gate used `npm whoami`, which proves READ auth only. Under `two-factor auth: auth-and-writes`, a valid token still can't publish non-interactively, so whoami greenlights and the OTP wall isn't hit until the very end.

**Fix:** shared `ensurePublishAuth()` in release-utils, called up front (before the preflight) by release-alpha, publish-alpha, and ship-alpha-no-checks:
- `npm whoami` — no token → `npm login --auth-type=web` (browser).
- token present but account is `auth-and-writes` 2FA (and no `NPM_TOKEN` bypass) → refresh login via browser NOW, so the interaction lands at minute 0, not minute 18.
- `NPM_TOKEN` (automation token, bypasses 2FA) → whoami is sufficient, no re-login.
- Idempotent across the release→publish subprocess via `__ALPHA_AUTH_VERIFIED`.

Validated: 2FA detection regex matches real `npm profile get`; guard + automation-token paths return without login; the live 2FA path opens the browser as designed.