### PR TITLE
docs(less): document unitMode; strictUnits is its deprecated alias

### DIFF
--- a/packages/docs/docs-content/docs/less/usage/less-options.md
+++ b/packages/docs/docs-content/docs/less/usage/less-options.md
@@ -194,15 +194,15 @@ _This has been replaced by the [`math`](#math) option._
 _Has been replaced by `rewriteUrls: "all"`_
 
 
-### Strict Units
+### Unit Mode
 
 | | |
 |---|---|
-| `lessc -su=on`<br>`lessc --strict-units=on` | `{ strictUnits: true }` |
+| `lessc --unit-mode=MODE` | `{ unitMode: MODE }` |
 
-Defaults to off/false.
+`MODE` is one of `loose` (the default), `strict`, or `preserve`, and controls how unit conversions are handled in math operations.
 
-Without this option, Less attempts to guess at the output unit when it does maths. For instance
+Without strict units, Less attempts to guess at the output unit when it does maths. For instance
 
 ```less
 .class {
@@ -212,7 +212,17 @@ Without this option, Less attempts to guess at the output unit when it does math
 
 In this case, things are clearly not right - a length multiplied by a length gives an area, but css does not support specifying areas. So we assume that the user meant for one of the values to be a value, not a unit of length and we output `2px`.
 
-With strict units on, we assume this is a bug in the calculation and throw an error.
+- `loose` — this guessing behavior (the Less 1.x–4.x default).
+- `strict` — assume this is a bug in the calculation and throw an error.
+- `preserve` — emit a `calc()` expression for unit compositions CSS can't express (like the example above) instead of guessing or erroring.
+
+#### Strict Units (deprecated)
+
+| | |
+|---|---|
+| `lessc -su=on`<br>`lessc --strict-units=on` | `{ strictUnits: true }` |
+
+_Deprecated alias for `unitMode`: `on` / `true` sets `unitMode: 'strict'`; `off` / `false` (the default) defers to `unitMode`. `lessc` prints a deprecation warning when it is used._
 
 #### IE8 Compatibility (Deprecated)
 


### PR DESCRIPTION
The Less options doc only described the 4.x `strictUnits` flag. `unitMode` (`loose` | `strict` | `preserve`) is the option — `core/src/types/config.ts:157` — and `strictUnits` is its documented `@deprecated` alias (`true` → `strict`; `false`/`off` defers to `unitMode`). `lessc` in Less 5 now accepts `--unit-mode=MODE` and prints a deprecation warning for `--strict-units` (less/less.js#4520).

Rewrites the section around the existing `1px * 2px` example to cover all three modes. Wording verified against actual output: `loose` → `2px`, `preserve` → `calc(1px * 2px)`, `strict` → error.

Observation (not changed here): under `preserve`, `1px + 3em` still coerces to `4px` like `loose` rather than emitting `calc(1px + 3em)` — preserve only fires for compositions CSS cannot express. Flagging for an owner call on whether addition of incompatible units should also preserve.