### PR TITLE
fix(core): $property accessors resolve under nested output

### DIFF
--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -15694,6 +15694,9 @@ function emitBubbleBody(
 interface NestedLeafBuffer {
   readonly leaves: Leaf[];
   readonly flush: () => void;
+
+  /** The block whose `$name` property lookups see the leaves spliced here. */
+  readonly propertyScope: Frame;
 }
 
 /**
@@ -15813,7 +15816,7 @@ function emitNestedBody(
     }
     buf.length = 0;
   });
-  const inlineLeaves: NestedLeafBuffer = sharedLeaves ?? { leaves: buf, flush: flushBuf };
+  const inlineLeaves: NestedLeafBuffer = sharedLeaves ?? { leaves: buf, flush: flushBuf, propertyScope: frame };
   let rootTriviaCursor = frame.parent === null && sharedLeaves === undefined ? 0 : undefined;
   let rootTriviaSuppressedByDefinition = false;
   const rootTriviaExclusions = rootTriviaCursor === undefined
@@ -15869,6 +15872,17 @@ function emitNestedBody(
           }
           queueBodyTriviaBefore(bodyTrivia, node, buf, e);
           const pushLeaf = (leafNode: Declaration | Comment): void => {
+            /*
+             * [property-accessor] Publish the declaration for `$name` lookups
+             * exactly as the collapsed emitter does (its `propertyScope`): a
+             * spliced mixin/apply/loop body publishes into the block that owns
+             * the shared leaf buffer, while its values still evaluate in the
+             * call frame. The nested emitter skipped this, so `height: $width`
+             * was a name-not-found under the v5 default and fine when collapsed.
+             */
+            if (leafNode.type === 'Declaration') {
+              recordPropertyDeclaration(sharedLeaves?.propertyScope ?? frame, leafNode, frame);
+            }
             const leaf = attachPendingLeafBlockComments(buf, {
               node: leafNode,
               frame,

--- a/packages/jess/test/less/property-accessor-nested.test.ts
+++ b/packages/jess/test/less/property-accessor-nested.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { Compiler } from '../../src/index.js';
+import lessPlugin from '@jesscss/plugin-less';
+
+/*
+ * A `$name` property accessor must resolve the same declarations whether the
+ * output is nested (the Less 5 default) or collapsed; the nested emitter used
+ * to skip publishing declarations to the accessor timeline, so `$width` was a
+ * name-not-found error under the default and fine under collapseNesting.
+ */
+const render = (source: string, collapseNesting: boolean) =>
+  new Compiler({ compile: { plugins: [lessPlugin({ collapseNesting })] } })
+    .renderToResult({ source, language: 'less', extension: '.less' }, {});
+
+const cases: [string, string, RegExp][] = [
+  ['sibling', '.a { width: 100px; height: ($width / 2); }', /height: 50px/],
+  ['parent from nested rule', '.a { width: 100px; .b { height: $width; } }', /height: 100px/],
+  ['last wins', '.a { color: red; color: blue; b: $color; }', /b: blue/],
+  ['from a mixin body', '.m() { width: 100px; } .a { .m(); height: $width; }', /height: 100px/]
+];
+
+describe('$property accessor resolves identically nested and collapsed', () => {
+  for (const [name, source, expected] of cases) {
+    it(name, async () => {
+      const nested = await render(source, false);
+      const flat = await render(source, true);
+      expect(nested.errors, `${name} nested`).toHaveLength(0);
+      expect(flat.errors, `${name} collapsed`).toHaveLength(0);
+      expect(nested.css, `${name} nested`).toMatch(expected);
+      expect(flat.css, `${name} collapsed`).toMatch(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Under the default nested output for Less input, a `$name` property accessor failed with `resolve/name-not-found`, while the same file rendered correctly with `collapseNesting: true`:

```less
.box {
  width: 100px;
  height: ($width / 2);   // error nested, 50px collapsed
}
```

The flattened emitter records each emitted declaration into the property-accessor timeline that `$name` lookups read; the nested emitter pushed leaves without recording them, so a lookup never saw its siblings.

## Change

`emitNestedBody` now records declarations the same way. The nested leaf buffer carries the frame that owns it, so a spliced mixin, apply, or loop body publishes into the enclosing block (mirroring the flattened emitter's `propertyScope`) while its values still evaluate in the call frame.

## Tests

`packages/jess/test/less/property-accessor-nested.test.ts`: sibling, parent from a nested rule, last-wins, and from a mixin body, each asserting nested and collapsed output agree and produce no errors. Core suite (3249), the Less corpus ratchet (1408, exact), plugin-less and fns pass.