### PR TITLE
refactor(core): share leaf evaluation across nesting modes

### DIFF
--- a/docs/architecture/core/HANDOFF.md
+++ b/docs/architecture/core/HANDOFF.md
@@ -131,10 +131,11 @@ lookup, expansion, control-flow, import, or property-timeline function may read 
    existing `Frame`/`Leaf` spine. Move declaration/comment handling, nested-property
    expansion, property-timeline publication, definition/variable publication, and body
    trivia ownership into the one evaluator. Normalize `Leaf` construction to one field
-   shape and replace `pendingLeafBlockComments` with one closure-local nullable pending
-   comment slot beside the existing leaf buffer. The slot reuses the trivia-owned comment
-   list; it is not an expando on `Leaf[]`, a side table, a buffer wrapper, or a fresh empty
-   array/object per leaf. Both writers consume the same evaluated leaves.
+   shape and replace `pendingLeafBlockComments` with one owner-tagged nullable
+   pending-comment slot on the existing render context. Its two scalar fields reuse the
+   active `Leaf[]` identity and trivia-owned comment list; they are not an expando, side
+   table, buffer wrapper, or fresh empty array/object per leaf. Both writers consume the
+   same evaluated leaves.
    Red-to-green pins cover sibling/parent/mixin `$property` access and block-interior
    comments in both output modes.
    Add a source-level architecture ratchet that starts by naming both statement
@@ -4027,7 +4028,121 @@ involved.
 
 ## Aggressive Cutting Self-Prosecution
 
-- Latest pass: 2026-08-26 document-root static import fact publication under
+- Latest pass: 2026-09-03 V19 slice 1 shared lookup and leaf bookkeeping. This
+  is the first evaluator-fold slice and a correctness correction with no speed claim.
+- Architecture surface: `serialize.ts` declaration/comment evaluation, property
+  publication, callable-body trivia ownership, the existing render `Emit` context,
+  focused both-mode tests, forced-corpus manifest support, and the maintained Less
+  hot-path harness. Parser grammar, AST/CST schemas, public package APIs, and output
+  configuration policy are unchanged.
+- Separation/duplication: `evaluateLeafStatement` and `evaluateSilentStatement` now
+  own facts previously repeated in the collapsed and nested dispatchers. Every Leaf
+  uses the same field order; the shared evaluator constructs its Leaf directly to avoid
+  an added helper rung, while writer-only sites use `evaluatedLeaf`. The two dispatchers
+  remain only for later V19 slices.
+- Cumulative node weight: canonical AST/CST nodes and Frames gain zero fields.
+  Transient Leaves change from branch-dependent two-to-five-field shapes to one fixed
+  five-field shape. Every render-local Emit gains two nullable scalar fields for the
+  pending comment list and its exact `Leaf[]` owner.
+- New traversal: no source or AST traversal. Three bounded positive-comment emission
+  loops write the already-owned trailing comment list at document-root, direct at-rule,
+  and direct bubble boundaries; each performs one iteration per emitted comment.
+  Existing body walks call the shared evaluator once for each eligible
+  declaration/comment. Temporary instrumentation measured N=4 as 4 evaluator visits/4
+  writer callbacks, 2N=8 as 8/8, and two separate N projections as 8/8 total. A
+  disposable doubled visit made the assertion fail at 4 rather than 2.
+- New node/materialization: zero AST/CST nodes, retained evaluated trees, wrappers,
+  group arrays, Maps, Sets, or per-entry objects. WeakMap constructions fall 7 to 6;
+  the deleted comment side table and conditional Leaf clones are replaced by two
+  scalar context slots that reuse existing buffer/list identities.
+- Render path: both projections still stream to the canonical `Emit.chunks` buffer.
+  Root, direct at-rule, bubble, collapsed, and nested flushes consume only trivia owned
+  by their exact leaf buffer. Capture-only `each(.mixin())` expansion saves, clears, and
+  restores the two scalars rather than allocating isolated side storage.
+- Helper/API surface: private serializer helpers only. Statically named functions stay
+  421 to 421 and arrow sites fall 585 to 584. A simple declaration calls
+  `evaluateLeafStatement`, constructs its fixed Leaf directly, and deletes the prior
+  local placement plus attachment-helper calls: net zero evaluator/writer helper rungs.
+  Ordinary mixin and nested-rule placement also add zero net helper rungs.
+- Metadata mutations: only the two render-local pending-trivia scalars mutate. Canonical
+  source nodes, Frames, source ownership, parser trivia, and public results are untouched.
+- Review-flagged diff tokens: [side map] the per-buffer WeakMap is deleted; [object shape]
+  Leaf becomes one monomorphic five-field shape and Emit gains two fixed nullable slots;
+  [array/materialization] existing active `Leaf[]` and trivia-owned comment arrays are
+  reused; [loop/traversal] three positive-comment loops consume only the already-owned
+  list, once per emitted comment, with no source or AST scan; [helper-call] zero net rungs
+  for a declaration, ordinary mixin, and nested-rule placement; [routine error control]
+  `forItemsFromMixinCall` catches only an exceptional synchronous expansion failure to
+  restore outer transient ownership, while success, misses, and async success remain on
+  their direct existing paths; [source scan/reparse] none.
+- Evidence: focused property/comment/trivia review passes 25/25; the expanded both-mode
+  selection passes 66 with 5 todo; normal all-less passes 112/112; forced-collapse
+  before/after manifests have 111 records and identical SHA-256
+  `ab837140229078bfd56a5ab47fe07dc26ceaf34b339f68e8adab67da4ec5499c` with zero
+  changed names. Jess ratchet passes 1,421 tests with zero current, gating-baseline, or
+  flaky-baseline failures. Dependents pass plugin-less 14/14, fns 718/718, and
+  plugin-scss 2/2.
+- Behavior evidence: both modes now publish the same declaration/property facts and
+  retain callable trivia at nested, root, and at-rule buffer boundaries. Two focused
+  comment-only cases intentionally correct collapsed output that previously dropped the
+  comment; the maintained forced-collapse corpus remains byte-identical. Capture-only
+  iterable trivia remains discarded and cannot leak into the caller. A disposable
+  removal of the shared property-publication calls made all four focused accessor cases
+  fail in both modes and changed the forced-corpus `functions`, `property-accessors`, and
+  `property-targeted` records; restoring the calls returned those gates to green.
+- Build evidence: dependency-ordered `pnpm run build:release` and the final core build
+  pass. The required root `npx vitest run packages/core` gate is green: 199 files
+  passed / 1 skipped and 3,189 tests passed / 9 skipped / 2 todo. The package-local
+  full core run is also green: 209 files and 3,253 tests passed / 8 skipped / 2 todo.
+  Static counts are `serialize.ts` 17,013 to 17,089 lines, Map 58 to 58, Set 34 to 34,
+  WeakMap 7 to 6, Leaf-group sites 9 to 9, conditional Leaf spreads 5 to 0, and
+  evaluator-side `e.collapse` reads 2 to 2 for this first slice. A disposable seventh
+  `new WeakMap` made the source ratchet fail at 7 versus 6 before it was removed.
+- Boundary evidence: no public type/export changes. Semantics review approves all eight
+  invariants under SETTLED V19 and G28. Performance review approves invariants 1-11 and
+  incidents R1-R8 structurally after owner-lifetime and corpus-provenance findings were
+  fixed; final approval is tied to this evidence block and the aggressive-cutting gate.
+- Hot-path cost contracts:
+```json
+[
+  {
+    "id": "ast-semantic-runtime-cutover",
+    "verdict": "accepted",
+    "performanceClaim": "none",
+    "owner": "the canonical AST-v2 evaluator/value/extend owners listed by ast-semantic-runtime-cutover",
+    "cases": [
+      "ValueSlot-array-evaluation-and-authored-layout",
+      "List-value-separator-and-Block-delimiter-facts",
+      "reference-index-and-For-array-access",
+      "Less-lazy-color-call-demand-boundary",
+      "defineFunction-typed-positional-named-and-lazy-binding",
+      "mixin-dispatch-ValueSlot-argument-resolution",
+      "ValueLayout-provenance-side-table",
+      "preserve-mode-calc-result-composition",
+      "extend-composition-plan-and-fixpoint-solve",
+      "Less-eager-bare-slash-precedence-and-parens-division",
+      "recursive-ValueGroup-final-unit-validation",
+      "async-declaration-dedup-output-order"
+    ],
+    "why": "SETTLED V19 makes evaluation and lookup functions of the source stylesheet, independent of nesting output. Slice 1 centralizes leaf facts and trivia ownership while retaining the existing streaming spine and two writers.",
+    "dangerTokensJustification": "One fixed Leaf field order and two fixed Emit scalars replace five conditional field spreads, a WeakMap side table, its eight operations, and comment-associated Leaf cloning. The shared evaluator constructs its Leaf directly, leaving declaration, mixin, and nested-rule placement at zero net added helper rungs. N/2N probes measured exactly one evaluator visit and writer callback per eligible statement. The only new try/catch restores transient state after a real exceptional synchronous failure.",
+    "behaviorEvidence": "Focused both-mode tests, full core, Jess ratchet, normal all-less, and dependent suites pass. The forced-collapse 111-record manifest is byte-identical before/after; two focused collapsed comment omissions are intentionally corrected outside that corpus.",
+    "buildEvidence": "Dependency-ordered build:release passes. Static counts are named functions 421 unchanged, arrows 585 to 584, Map 58 unchanged, Set 34 unchanged, WeakMap 7 to 6, groups 9 unchanged, and conditional Leaf spreads 5 to 0. Same-session Node 24.11.1 hot-path timings are inconclusive: same-commit null drift reaches -19.9%/+9.5%; a disposable shared-evaluator control moves functions from 4.33/4.13 ms to 18.34/18.19 ms in collapsed/nested modes.",
+    "baseline": {
+      "fixture": "benchmark.less",
+      "phase": "render",
+      "currentMedianMs": 47.37,
+      "outputSha256": "2b8d9abf3c103a6de7a0a5d66b3a448bcaef8c1818eff753de52d25a23b98f7d",
+      "outputBytes": 122568
+    }
+  }
+]
+```
+- Verdict: accepted as the smallest V19 leaf/fact fold after the owner-tag lifetime,
+  exceptional restore, and benchmark corpus-provenance findings were addressed. No
+  speed or neutrality claim is made; timing remains explicitly inconclusive.
+
+- Previous pass: 2026-08-26 document-root static import fact publication under
   OPEN N10. This is a Less compatibility correction with no speed claim.
 - Architecture surface: the existing AST-v2 static import planner and lexical
   import emitter in `serialize.ts`, the opaque `PreparedImports` token, focused

--- a/docs/perf/BENCHMARKS.md
+++ b/docs/perf/BENCHMARKS.md
@@ -48,7 +48,7 @@ known gap to fill when total-eval-vs-4.x becomes a focus.
 
 - Run: `pnpm run measure:less:hotpath` (measure only) / `pnpm run measure:less:hotpath:record` (save + compare to latest).
 - Script: `scripts/measure-less-hotpath.mjs`. Fixtures (default): `tests-unit/{functions,import/import-reference,mixins-guards,extend-chaining,media}` from the `@less/test-data` corpus. Override with `--fixture <rel>`; select the writer explicitly with `--collapse-nesting true|false` (default `true`); set `JESS_LESS_TEST_DATA_ROOT` when a workspace's `link:` dependency does not resolve from the repository root; other flags: `--iterations N`, `--save`, `--history <file>`, `--compare-latest`.
-- History file: `docs/perf/node-copy-reduction/less-hotpath-history.jsonl` (append-only via `--save`). Each new run records the real corpus root, package version, and Git commit. Comparisons reject a conflicting recorded corpus identity while retaining compatibility with legacy records that predate those fields.
+- History file: `docs/perf/node-copy-reduction/less-hotpath-history.jsonl` (append-only via `--save`). Each new run records the real corpus root and package version, plus the corpus Git commit when it has a Git top-level distinct from the Jess checkout. Comparisons reject a conflicting recorded corpus identity while retaining compatibility with legacy records that predate those fields.
 - Reports a stability `signal` (usable/unstable) per fixture — quote it; a contended machine reads "unstable".
 
 ## 3. perf:ab — jess vs an older jess commit (cross-worktree)

--- a/docs/perf/BENCHMARKS.md
+++ b/docs/perf/BENCHMARKS.md
@@ -47,8 +47,8 @@ known gap to fill when total-eval-vs-4.x becomes a focus.
 ## 2. measure:less:hotpath — jess render timing
 
 - Run: `pnpm run measure:less:hotpath` (measure only) / `pnpm run measure:less:hotpath:record` (save + compare to latest).
-- Script: `scripts/measure-less-hotpath.mjs`. Fixtures (default): `tests-unit/{functions,import/import-reference,mixins-guards,extend-chaining,media}` from the `@less/test-data` corpus. Override with `--fixture <rel>`; select the writer explicitly with `--collapse-nesting true|false` (default `true`); other flags: `--iterations N`, `--save`, `--history <file>`, `--compare-latest`.
-- History file: `docs/perf/node-copy-reduction/less-hotpath-history.jsonl` (append-only via `--save`).
+- Script: `scripts/measure-less-hotpath.mjs`. Fixtures (default): `tests-unit/{functions,import/import-reference,mixins-guards,extend-chaining,media}` from the `@less/test-data` corpus. Override with `--fixture <rel>`; select the writer explicitly with `--collapse-nesting true|false` (default `true`); set `JESS_LESS_TEST_DATA_ROOT` when a workspace's `link:` dependency does not resolve from the repository root; other flags: `--iterations N`, `--save`, `--history <file>`, `--compare-latest`.
+- History file: `docs/perf/node-copy-reduction/less-hotpath-history.jsonl` (append-only via `--save`). Each new run records the real corpus root, package version, and Git commit. Comparisons reject a conflicting recorded corpus identity while retaining compatibility with legacy records that predate those fields.
 - Reports a stability `signal` (usable/unstable) per fixture — quote it; a contended machine reads "unstable".
 
 ## 3. perf:ab — jess vs an older jess commit (cross-worktree)

--- a/docs/perf/BENCHMARKS.md
+++ b/docs/perf/BENCHMARKS.md
@@ -47,7 +47,7 @@ known gap to fill when total-eval-vs-4.x becomes a focus.
 ## 2. measure:less:hotpath — jess render timing
 
 - Run: `pnpm run measure:less:hotpath` (measure only) / `pnpm run measure:less:hotpath:record` (save + compare to latest).
-- Script: `scripts/measure-less-hotpath.mjs`. Fixtures (default): `tests-unit/{functions,import/import-reference,mixins-guards,extend-chaining,media}` from the `@less/test-data` corpus. Override with `--fixture <rel>`; other flags: `--iterations N`, `--save`, `--history <file>`, `--compare-latest`.
+- Script: `scripts/measure-less-hotpath.mjs`. Fixtures (default): `tests-unit/{functions,import/import-reference,mixins-guards,extend-chaining,media}` from the `@less/test-data` corpus. Override with `--fixture <rel>`; select the writer explicitly with `--collapse-nesting true|false` (default `true`); other flags: `--iterations N`, `--save`, `--history <file>`, `--compare-latest`.
 - History file: `docs/perf/node-copy-reduction/less-hotpath-history.jsonl` (append-only via `--save`).
 - Reports a stability `signal` (usable/unstable) per fixture — quote it; a contended machine reads "unstable".
 

--- a/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
+++ b/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SERIALIZE_PATH = fileURLToPath(new URL('../serialize.ts', import.meta.url));
+const SOURCE = readFileSync(SERIALIZE_PATH, 'utf8');
+
+function occurrences(pattern: RegExp): number {
+  return [...SOURCE.matchAll(pattern)].length;
+}
+
+describe('V19 one-evaluator projection ratchet', () => {
+  it('names every statement evaluator that still dispatches a body', () => {
+    const dispatchers = [
+      ['walkBody', /function walkBody\(/u],
+      ['emitNestedBody', /function emitNestedBody\(/u]
+    ].filter(([, pattern]) => pattern.test(SOURCE)).map(([name]) => name);
+
+    expect(dispatchers).toEqual(['walkBody', 'emitNestedBody']);
+  });
+
+  it('names every output-setting read that can select evaluation behavior', () => {
+    expect(occurrences(/\be\.collapse\b/gu)).toBe(2);
+    expect(SOURCE).toContain(
+      'if (!e.collapse && e.referenceImportDepth === 0 && !hasDynamicImportTarget)'
+    );
+    expect(SOURCE).toContain('function emitNestedRuleGuarded(');
+    expect(SOURCE).toContain('  if (!e.collapse) {');
+  });
+
+  it('pins the leaf-shape and pending-comment debt removed by slice 1', () => {
+    expect(occurrences(/new WeakMap<Leaf\[\], string\[\]>\(\)/gu)).toBe(1);
+    expect(occurrences(/pendingLeafBlockComments\.(?:get|set|delete)\(/gu)).toBe(8);
+    expect(occurrences(/\.\.\.\(imp \? \{ important: true \} : \{\}\)/gu)).toBe(3);
+    expect(occurrences(/\.\.\.\(applyExpansion \? \{ fromApply: true \} : \{\}\)/gu)).toBe(2);
+  });
+});

--- a/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
+++ b/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
@@ -28,10 +28,26 @@ describe('V19 one-evaluator projection ratchet', () => {
     expect(SOURCE).toContain('  if (!e.collapse) {');
   });
 
-  it('pins the leaf-shape and pending-comment debt removed by slice 1', () => {
-    expect(occurrences(/new WeakMap<Leaf\[\], string\[\]>\(\)/gu)).toBe(1);
-    expect(occurrences(/pendingLeafBlockComments\.(?:get|set|delete)\(/gu)).toBe(8);
-    expect(occurrences(/\.\.\.\(imp \? \{ important: true \} : \{\}\)/gu)).toBe(3);
-    expect(occurrences(/\.\.\.\(applyExpansion \? \{ fromApply: true \} : \{\}\)/gu)).toBe(2);
+  it('keeps one leaf shape and no pending-comment side table', () => {
+    expect(occurrences(/new WeakMap<Leaf\[\], string\[\]>\(\)/gu)).toBe(0);
+    expect(occurrences(/pendingLeafBlockComments\.(?:get|set|delete)\(/gu)).toBe(0);
+    expect(occurrences(/\.\.\.\(imp \? \{ important: true \} : \{\}\)/gu)).toBe(0);
+    expect(occurrences(/\.\.\.\(applyExpansion \? \{ fromApply: true \} : \{\}\)/gu)).toBe(0);
+    expect(occurrences(/return \{ node, frame, important, leadingBlockComments, fromApply \};/gu)).toBe(1);
+    expect(occurrences(/place\(\{ node, frame, important, leadingBlockComments: null, fromApply \}\);/gu)).toBe(2);
+    expect(occurrences(/place\(\{ node: part, frame, important, leadingBlockComments: null, fromApply \}\);/gu)).toBe(1);
+    expect(SOURCE).toContain('pendingLeafBlockComments: string[] | null;');
+    expect(SOURCE).toContain('pendingLeafBlockCommentOwner: Leaf[] | null;');
+  });
+
+  it('does not grow the serializer helper or collection-construction surface', () => {
+    expect(occurrences(/^function |^async function /gmu)).toBe(421);
+    expect(occurrences(/new Map/gu)).toBe(58);
+    expect(occurrences(/new Set/gu)).toBe(34);
+    expect(occurrences(/new WeakMap/gu)).toBe(6);
+    expect(occurrences(/const group: Leaf\[\] = \[\]/gu)).toBe(9);
+    expect(occurrences(/const buf = .*\?\? \[\]/gu)).toBe(1);
+    expect(occurrences(/evaluateLeafStatement\(/gu)).toBe(3);
+    expect(occurrences(/evaluateSilentStatement\(/gu)).toBe(5);
   });
 });

--- a/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
+++ b/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
@@ -11,10 +11,10 @@ function occurrences(pattern: RegExp): number {
 
 describe('V19 one-evaluator projection ratchet', () => {
   it('names every statement evaluator that still dispatches a body', () => {
-    const dispatchers = [
+    const dispatchers = ([
       ['walkBody', /function walkBody\(/u],
       ['emitNestedBody', /function emitNestedBody\(/u]
-    ].filter(([, pattern]) => pattern.test(SOURCE)).map(([name]) => name);
+    ] as const).filter(([, pattern]) => pattern.test(SOURCE)).map(([name]) => name);
 
     expect(dispatchers).toEqual(['walkBody', 'emitNestedBody']);
   });

--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -7065,6 +7065,12 @@ interface Emit extends EvalCtx {
 
   /** Block-comment trivia runs already replayed during this render. */
   emittedBlockTrivia: EmittedTrivia;
+
+  /** Pending trivia owned by the currently active leaf buffer. */
+  pendingLeafBlockComments: string[] | null;
+
+  /** Identity of the leaf buffer that owns {@link pendingLeafBlockComments}. */
+  pendingLeafBlockCommentOwner: Leaf[] | null;
 }
 
 /**
@@ -7118,7 +7124,9 @@ function scratchEmit(e: EvalCtx): Emit {
     prepublishedImportFacts: null,
     plannedForExtendPlacements: null,
     hoistedCssImports: null,
-    emittedBlockTrivia: new EmittedTrivia()
+    emittedBlockTrivia: new EmittedTrivia(),
+    pendingLeafBlockComments: null,
+    pendingLeafBlockCommentOwner: null
   };
 }
 
@@ -8390,48 +8398,97 @@ function hasBodyBlockCommentTrivia(owner: object, e: Emit): boolean {
 interface Leaf {
   node: Statement;
   frame: Frame;
-  important?: boolean;
-  leadingBlockComments?: readonly string[];
+  important: boolean;
+  leadingBlockComments: readonly string[] | null;
 
   /** Produced by the core `$apply` expansion; its repeated output stays visible. */
-  fromApply?: true;
+  fromApply: boolean;
 }
 
-const pendingLeafBlockComments = new WeakMap<Leaf[], string[]>();
-const EMPTY_LEAF_BLOCK_COMMENTS: readonly string[] = Object.freeze([]);
-
-function hasPendingLeafBlockComments(group: Leaf[]): boolean {
-  return (pendingLeafBlockComments.get(group)?.length ?? 0) !== 0;
+function evaluatedLeaf(
+  node: Statement,
+  frame: Frame,
+  important = false,
+  fromApply = false,
+  leadingBlockComments: readonly string[] | null = null
+): Leaf {
+  return { node, frame, important, leadingBlockComments, fromApply };
 }
 
-function takePendingLeafBlockComments(group: Leaf[]): readonly string[] {
-  const pending = pendingLeafBlockComments.get(group);
-  if (pending === undefined) {
+const EMPTY_LEAF_BLOCK_COMMENTS: string[] = [];
+
+function takePendingLeafBlockComments(e: Emit, owner: Leaf[]): string[] {
+  const pending = e.pendingLeafBlockCommentOwner === owner
+    ? e.pendingLeafBlockComments
+    : null;
+  if (pending === null) {
     return EMPTY_LEAF_BLOCK_COMMENTS;
   }
-  pendingLeafBlockComments.delete(group);
+  e.pendingLeafBlockComments = null;
+  e.pendingLeafBlockCommentOwner = null;
   return pending;
 }
 
-function queueLeafBlockComments(group: Leaf[], comments: string[]): void {
+function queueLeafBlockComments(e: Emit, owner: Leaf[], comments: string[]): void {
   if (comments.length === 0) {
     return;
   }
-  const pending = pendingLeafBlockComments.get(group);
-  if (pending === undefined) {
-    pendingLeafBlockComments.set(group, comments);
+  const pending = e.pendingLeafBlockCommentOwner === owner
+    ? e.pendingLeafBlockComments
+    : null;
+  if (pending === null) {
+    e.pendingLeafBlockComments = comments;
+    e.pendingLeafBlockCommentOwner = owner;
   } else {
     pending.push(...comments);
   }
 }
 
-function attachPendingLeafBlockComments(group: Leaf[], leaf: Leaf): Leaf {
-  const pending = pendingLeafBlockComments.get(group);
-  if (pending === undefined || pending.length === 0) {
-    return leaf;
+/** Evaluate the lookup-sensitive facts shared by both output projections. */
+function evaluateLeafStatement(
+  node: Declaration | Comment,
+  frame: Frame,
+  propertyScope: Frame,
+  e: Emit,
+  important: boolean,
+  fromApply: boolean,
+  bodyTrivia: BodyTriviaReplay | undefined,
+  group: Leaf[],
+  place: (leaf: Leaf) => void
+): void {
+  queueBodyTriviaBefore(bodyTrivia, node, group, e);
+  if (node.type === 'Comment') {
+    place({ node, frame, important, leadingBlockComments: null, fromApply });
+    return;
   }
-  pendingLeafBlockComments.delete(group);
-  return { ...leaf, leadingBlockComments: pending };
+
+  const parts = nestedPropertyDeclarations(node, frame, e);
+  if (parts === null) {
+    recordPropertyDeclaration(propertyScope, node, frame);
+    place({ node, frame, important, leadingBlockComments: null, fromApply });
+    return;
+  }
+  for (const part of parts) {
+    recordPropertyDeclaration(propertyScope, part, frame);
+    place({ node: part, frame, important, leadingBlockComments: null, fromApply });
+  }
+}
+
+/** Publish a definition/variable independently of the selected writer. */
+function evaluateSilentStatement(
+  node: MixinDefinition | VariableDeclaration,
+  frame: Frame,
+  e: Emit
+): boolean {
+  if (node.type === 'MixinDefinition') {
+    publishSelectedMixinDefinition(frame, node);
+    return true;
+  }
+  activateVariableDeclaration(node, frame, e);
+  markSilentStatementBlockCommentTrivia(node, e);
+  return !isValueSlotArray(node.value)
+    && 'type' in node.value
+    && isValueBlock(node.value);
 }
 
 /** The resolved property name of a declaration (interp names resolve sync). */
@@ -9238,6 +9295,8 @@ export function prepareStaticImports(root: Stylesheet, options?: PrepareStaticIm
     plannedForExtendPlacements: null,
     hoistedCssImports: null,
     emittedBlockTrivia: new EmittedTrivia(),
+    pendingLeafBlockComments: null,
+    pendingLeafBlockCommentOwner: null,
     scopedFunctionNames: scopedFunctionNames(rootFns),
     lambdaFunctionNames: new Set(),
     fnScopeVersion: 0,
@@ -9321,6 +9380,8 @@ export function serialize(root: Stylesheet, options?: SerializeOptions): Seriali
     plannedForExtendPlacements: null,
     hoistedCssImports: null,
     emittedBlockTrivia: new EmittedTrivia(),
+    pendingLeafBlockComments: null,
+    pendingLeafBlockCommentOwner: null,
     scopedFunctionNames: scopedFunctionNames(rootFns), // absent idle ⇒ fn-dispatch walk skipped
     lambdaFunctionNames: new Set(), // [lambda-fn] empty idle ⇒ user-`@function` lookup skipped
     fnScopeVersion: 0,
@@ -9521,6 +9582,21 @@ function emitDocumentStatements(
   const markAfterDocumentStatement = (child: Statement): void => {
     documentTriviaCursor = statementEndOf(child) ?? documentTriviaCursor;
   };
+  const flushDocumentGroup = (group: Leaf[]): MaybePromise<void> => {
+    const trailingBlockComments = takePendingLeafBlockComments(e, group);
+    if (group.length) {
+      return mapMaybe(
+        flushBlock([], group, e, undefined, undefined, undefined, trailingBlockComments),
+        () => {
+          group.length = 0;
+        }
+      );
+    }
+    for (const comment of trailingBlockComments) {
+      put(e, comment);
+      put(e, '\n');
+    }
+  };
   const run = (child: Statement, allowDefer: boolean): MaybePromise<void> => {
     try {
       return emit(child);
@@ -9579,13 +9655,7 @@ function emitDocumentStatements(
           break;
         }
         const group: Leaf[] = [];
-        const flush = (): MaybePromise<void> => {
-          if (group.length) {
-            return mapMaybe(flushBlock([], group, e), () => {
-              group.length = 0;
-            });
-          }
-        };
+        const flush = (): MaybePromise<void> => flushDocumentGroup(group);
         return mapMaybe(expandCall(child, null, null, frame, group, flush, null, e), flush);
       }
       case 'Apply': {
@@ -9593,13 +9663,7 @@ function emitDocumentStatements(
           break;
         }
         const group: Leaf[] = [];
-        const flush = (): MaybePromise<void> => {
-          if (group.length) {
-            return mapMaybe(flushBlock([], group, e), () => {
-              group.length = 0;
-            });
-          }
-        };
+        const flush = (): MaybePromise<void> => flushDocumentGroup(group);
         return mapMaybe(expandApply(child, null, null, frame, group, flush, null, e), flush);
       }
       case 'Reference': {
@@ -9609,13 +9673,7 @@ function emitDocumentStatements(
 
         // A final call step can splice a detached ruleset at document level.
         const group: Leaf[] = [];
-        const flush = (): MaybePromise<void> => {
-          if (group.length) {
-            return mapMaybe(flushBlock([], group, e), () => {
-              group.length = 0;
-            });
-          }
-        };
+        const flush = (): MaybePromise<void> => flushDocumentGroup(group);
         return mapMaybe(expandReferenceCall(child, null, null, frame, group, flush, null, e), flush);
       }
       case 'For': {
@@ -9625,13 +9683,7 @@ function emitDocumentStatements(
 
         // a top-level `each(...)` loop — its body emits at the document level.
         const group: Leaf[] = [];
-        const flush = (): MaybePromise<void> => {
-          if (group.length) {
-            return mapMaybe(flushBlock([], group, e), () => {
-              group.length = 0;
-            });
-          }
-        };
+        const flush = (): MaybePromise<void> => flushDocumentGroup(group);
         return mapMaybe(expandFor(child, null, null, frame, group, flush, null, e), flush);
       }
       case 'If': {
@@ -9643,13 +9695,7 @@ function emitDocumentStatements(
           break;
         }
         const group: Leaf[] = [];
-        const flush = (): MaybePromise<void> => {
-          if (group.length) {
-            return mapMaybe(flushBlock([], group, e), () => {
-              group.length = 0;
-            });
-          }
-        };
+        const flush = (): MaybePromise<void> => flushDocumentGroup(group);
         return mapMaybe(walkBody(body, null, null, frame, group, flush, null, e), flush);
       }
       case 'While': {
@@ -9657,13 +9703,7 @@ function emitDocumentStatements(
           break;
         }
         const group: Leaf[] = [];
-        const flush = (): MaybePromise<void> => {
-          if (group.length) {
-            return mapMaybe(flushBlock([], group, e), () => {
-              group.length = 0;
-            });
-          }
-        };
+        const flush = (): MaybePromise<void> => flushDocumentGroup(group);
         return mapMaybe(
           runWhile(child, frame, e, rules => walkBody(rules, null, null, frame, group, flush, null, e)),
           flush
@@ -9673,7 +9713,7 @@ function emitDocumentStatements(
       case 'Comment':
         if (e.referenceImportDepth === 0) {
           emitBeforeDocumentStatement(child);
-          emitLeaf({ node: child, frame }, e, true);
+          emitLeaf(evaluatedLeaf(child, frame), e, true);
           markAfterDocumentStatement(child);
         }
         break;
@@ -10251,13 +10291,17 @@ function flattenWithHeader(
   const visible = header!;
   const group: Leaf[] = [];
   const flush = (): MaybePromise<void> => {
-    if (group.length || hasPendingLeafBlockComments(group)) {
+    if (group.length || e.pendingLeafBlockCommentOwner === group) {
+      const trailingBlockComments = takePendingLeafBlockComments(e, group);
+
       /*
        * [adjacent-merge] `parent` (the parent expansion this rule was composed
        * against) keys sibling merges: two nested rulesets with the same parent ref
        * and header merge; top-level rules (`parent === null`) never do.
        */
-      return mapMaybe(flushBlock(visible, group, e, rule.selector, parent, rule), () => {
+      return mapMaybe(flushBlock(
+        visible, group, e, rule.selector, parent, rule, trailingBlockComments
+      ), () => {
         group.length = 0;
       });
     }
@@ -10269,9 +10313,14 @@ function flattenWithHeader(
    * that ordered stream; it must never regroup a later parent declaration ahead
    * of an emitted child merely to make the selector output smaller.
    */
-  const emitBlock = (leaves: Leaf[]): MaybePromise<void> => {
-    if (leaves.length || hasPendingLeafBlockComments(leaves)) {
-      return flushBlock(visible, leaves, e, rule.selector, parent, rule);
+  const emitBlock = (
+    leaves: Leaf[],
+    trailingBlockComments: readonly string[]
+  ): MaybePromise<void> => {
+    if (leaves.length || trailingBlockComments.length !== 0) {
+      return flushBlock(
+        visible, leaves, e, rule.selector, parent, rule, trailingBlockComments
+      );
     }
   };
   const partition: Partition = {
@@ -10290,12 +10339,14 @@ function flattenWithHeader(
       }
     };
     if (!partition.encounteredContainer) {
-      if (group.length === 0 && !hasPendingLeafBlockComments(group) && hasBodyBlockCommentTrivia(rule, e)) {
-        return flushBlock(visible, [], e, rule.selector, parent, rule);
+      if (group.length === 0 && e.pendingLeafBlockCommentOwner !== group && hasBodyBlockCommentTrivia(rule, e)) {
+        return flushBlock(
+          visible, [], e, rule.selector, parent, rule, EMPTY_LEAF_BLOCK_COMMENTS
+        );
       }
       return flush();
     }
-    queueLeadingGroup(group, partition);
+    queueLeadingGroup(group, partition, e);
     flushPending(partition);
     return runTrailing(0);
   };
@@ -10328,15 +10379,24 @@ function flattenWithHeader(
 }
 
 /** [partition] Queue the direct leaves preceding a collapsed child as one parent block. */
-function queueLeadingGroup(group: Leaf[], p: Partition): void {
-  if (group.length || hasPendingLeafBlockComments(group)) {
+function queueLeadingGroup(group: Leaf[], p: Partition, e: Emit): void {
+  if (group.length || e.pendingLeafBlockCommentOwner === group) {
     const batch = group.splice(0, group.length);
-    const trailing = takePendingLeafBlockComments(group);
-    if (trailing.length > 0) {
-      pendingLeafBlockComments.set(batch, [...trailing]);
-    }
+    let trailingBlockComments = takePendingLeafBlockComments(e, group);
+    const emit = (additionalBlockComments?: string[]): MaybePromise<void> => {
+      if (additionalBlockComments !== undefined) {
+        if (trailingBlockComments.length === 0) {
+          trailingBlockComments = additionalBlockComments;
+        } else {
+          trailingBlockComments.push(...additionalBlockComments);
+        }
+        return;
+      }
+      return p.emitBlock(batch, trailingBlockComments);
+    };
     p.lastLeadingGroup = batch;
-    p.trailing.push(() => p.emitBlock(batch));
+    p.lastLeadingEmission = emit;
+    p.trailing.push(emit);
   }
 }
 
@@ -10345,7 +10405,7 @@ function flushPending(p: Partition): void {
   if (p.pending.length) {
     const batch = p.pending;
     p.pending = [];
-    p.trailing.push(() => p.emitBlock(batch));
+    p.trailing.push(() => p.emitBlock(batch, EMPTY_LEAF_BLOCK_COMMENTS));
   }
 }
 
@@ -10355,15 +10415,20 @@ function addLeaf(
   partition: Partition | null,
   leaf: Leaf,
   _forceLeading: boolean,
-  e: Emit,
-  bodyTrivia?: BodyTriviaReplay
+  e: Emit
 ): void {
-  queueBodyTriviaBefore(bodyTrivia, leaf.node, group, e);
-  const next = attachPendingLeafBlockComments(group, leaf);
+  const pendingBlockComments = e.pendingLeafBlockCommentOwner === group
+    ? e.pendingLeafBlockComments
+    : null;
+  if (pendingBlockComments !== null) {
+    e.pendingLeafBlockComments = null;
+    e.pendingLeafBlockCommentOwner = null;
+    leaf.leadingBlockComments = pendingBlockComments;
+  }
   if (partition && partition.encounteredContainer) {
-    partition.pending.push(next);
+    partition.pending.push(leaf);
   } else {
-    group.push(next);
+    group.push(leaf);
   }
 }
 
@@ -10437,7 +10502,7 @@ function queueBodyTriviaBefore(
     }
   }
   if (comments !== undefined) {
-    queueLeafBlockComments(group, comments);
+    queueLeafBlockComments(e, group, comments);
   }
 }
 
@@ -10464,11 +10529,11 @@ function queueBodyTriviaTail(
   if (replay === undefined) {
     return;
   }
+  let comments: string[] | undefined;
+  const table = replay.table;
   const target = partition?.encounteredContainer === true && partition.lastLeadingGroup !== undefined
     ? partition.lastLeadingGroup
     : group;
-  let comments: string[] | undefined;
-  const table = replay.table;
   const previousLeaf = target[target.length - 1];
   const inlineStart = previousLeaf === undefined ? undefined : statementEndOf(previousLeaf.node);
   while (replay.index < table.runs.length) {
@@ -10490,7 +10555,11 @@ function queueBodyTriviaTail(
     }
   }
   if (comments !== undefined) {
-    queueLeafBlockComments(target, comments);
+    if (target === partition?.lastLeadingGroup && partition.lastLeadingEmission !== undefined) {
+      partition.lastLeadingEmission(comments);
+    } else {
+      queueLeafBlockComments(e, target, comments);
+    }
   }
 }
 
@@ -10511,10 +10580,16 @@ interface Partition {
   pending: Leaf[];
 
   /** Emit a run of leaves as ONE block reusing this ruleset's header + merge key. */
-  emitBlock: (leaves: Leaf[]) => MaybePromise<void>;
+  emitBlock: (
+    leaves: Leaf[],
+    trailingBlockComments: readonly string[]
+  ) => MaybePromise<void>;
 
   /** The direct run that immediately precedes the next collapsed child. */
   lastLeadingGroup?: Leaf[];
+
+  /** Its queued writer; an argument transfers body-tail trivia before emission. */
+  lastLeadingEmission?: (additionalBlockComments?: string[]) => MaybePromise<void>;
 }
 
 /**
@@ -10539,58 +10614,32 @@ function walkBody(
   expandBubbledSelectorList = false,
   bodyTrivia?: BodyTriviaReplay
 ): MaybePromise<void> {
+  const placeLeaf = (leaf: Leaf): void => {
+    addLeaf(group, partition, leaf, forceLeading, e);
+  };
   for (let index = 0; index < statements.length; index++) {
     const node = statements[index]!;
     if (node.type !== 'Declaration' && node.type !== 'Comment') {
       queueBodyTriviaBefore(bodyTrivia, node, group, e);
     }
     switch (node.type) {
-      case 'Declaration': {
-        /*
-         * Property accessors see declarations in the order evaluation splices
-         * them into the enclosing ruleset. A mixin body retains its call frame for
-         * value evaluation but publishes this declaration into `propertyScope`.
-         */
-        const pushDeclLeaf = (declaration: Declaration): void => {
-          recordPropertyDeclaration(propertyScope, declaration, frame);
-
-          /*
-           * Every collapsed child is a source-order/cascade boundary. A declaration
-           * after it belongs to a later parent block, never the leading block.
-           */
-          addLeaf(group, partition, {
-            node: declaration,
-            frame,
-            ...(imp ? { important: true } : {}),
-            ...(applyExpansion ? { fromApply: true } : {})
-          }, forceLeading, e, bodyTrivia);
-        };
-
-        /*
-         * [nested-property] A property-root `{ … }` block expands to hyphenated
-         * declarations. Shared with the nested emitter — see
-         * {@link nestedPropertyDeclarations}.
-         */
-        const parts = nestedPropertyDeclarations(node, frame, e);
-        if (parts !== null) {
-          for (const part of parts) {
-            pushDeclLeaf(part);
-          }
-          break;
-        }
-        pushDeclLeaf(node);
-        break;
-      }
+      case 'Declaration':
       case 'Comment':
         /*
-         * [partition] A comment keeps its authored position relative to nested
-         * rules: before the first → leading block; after → its own trailing run.
+         * Lookup publication, nested-property expansion, and the monomorphic
+         * placement shape are evaluator facts shared by both output projections.
          */
-        addLeaf(group, partition, {
+        evaluateLeafStatement(
           node,
           frame,
-          ...(imp ? { important: true } : {})
-        }, forceLeading, e, bodyTrivia);
+          propertyScope,
+          e,
+          imp,
+          applyExpansion,
+          bodyTrivia,
+          group,
+          placeLeaf
+        );
         break;
       case 'Ruleset': {
         /*
@@ -10655,7 +10704,7 @@ function walkBody(
          * inline in source order.
          */
         if (partition) {
-          queueLeadingGroup(group, partition);
+          queueLeadingGroup(group, partition, e);
           flushPending(partition);
           partition.encounteredContainer = true;
           partition.trailing.push(() => flatten(rule, rComposed, rAncestor, rFrame, e, imp, expandBubbledSelectorList));
@@ -10764,7 +10813,7 @@ function walkBody(
          * leading block, matching the legacy flatten order.
          */
         if (staysNested(node.name)) {
-          addLeaf(group, partition, { node, frame }, forceLeading, e, bodyTrivia);
+          addLeaf(group, partition, evaluatedLeaf(node, frame), forceLeading, e);
           break;
         }
         const atNode = node;
@@ -10801,7 +10850,7 @@ function walkBody(
           return r;
         };
         if (partition) {
-          queueLeadingGroup(group, partition);
+          queueLeadingGroup(group, partition, e);
           flushPending(partition);
           partition.encounteredContainer = true;
           partition.trailing.push(emitAt);
@@ -10836,12 +10885,12 @@ function walkBody(
          * `@import` at root belongs.
          */
         if (staysNested(node.name) && composed !== null && composed.length > 0) {
-          addLeaf(group, partition, { node, frame }, forceLeading, e, bodyTrivia);
+          addLeaf(group, partition, evaluatedLeaf(node, frame), forceLeading, e);
           break;
         }
         const atNode = node;
         if (partition) {
-          queueLeadingGroup(group, partition);
+          queueLeadingGroup(group, partition, e);
           flushPending(partition);
           partition.encounteredContainer = true;
           partition.trailing.push(() => emitAtRuleStatement(atNode, frame, e));
@@ -10901,7 +10950,7 @@ function walkBody(
             ));
           }
         } else if (partition !== null && composed !== null) {
-          addLeaf(group, partition, { node, frame }, forceLeading, e, bodyTrivia);
+          addLeaf(group, partition, evaluatedLeaf(node, frame), forceLeading, e);
         } else {
           const flushed = flush();
           if (isThenable(flushed)) {
@@ -10932,7 +10981,7 @@ function walkBody(
       case 'ModuleImport': {
         const importNode = node;
         if (partition) {
-          queueLeadingGroup(group, partition);
+          queueLeadingGroup(group, partition, e);
           flushPending(partition);
           partition.encounteredContainer = true;
           partition.trailing.push(() => emitModuleImport(importNode, frame, e));
@@ -10954,7 +11003,7 @@ function walkBody(
       case 'UnknownAtRuleBlock': {
         const opaqueNode = node;
         if (partition) {
-          queueLeadingGroup(group, partition);
+          queueLeadingGroup(group, partition, e);
           flushPending(partition);
           partition.encounteredContainer = true;
           partition.trailing.push(() => emitUnknownAtRuleBlock(opaqueNode, e));
@@ -10979,15 +11028,14 @@ function walkBody(
        * decl group first so it emits at its authored position, then the line.
        */
       case 'FunctionCall': {
-        addLeaf(group, partition, { node, frame }, forceLeading, e, bodyTrivia);
+        addLeaf(group, partition, evaluatedLeaf(node, frame), forceLeading, e);
         break;
       }
       case 'MixinDefinition':
-        publishSelectedMixinDefinition(frame, node);
+        evaluateSilentStatement(node, frame, e);
         break;
       case 'VariableDeclaration':
-        activateVariableDeclaration(node, frame, e);
-        markSilentStatementBlockCommentTrivia(node, e);
+        evaluateSilentStatement(node, frame, e);
         break;
     }
   }
@@ -11406,14 +11454,6 @@ function expandCall(
   });
 }
 
-/** Queue retained trivia from already-selected unguarded empty mixin bodies. */
-function queueCommentOnlyBody(def: MixinDefinition, e: Emit, group: Leaf[]): void {
-  const comments = bodyBlockCommentTexts(def, e);
-  if (comments.length !== 0) {
-    queueLeafBlockComments(group, comments);
-  }
-}
-
 function queueCommentOnlySelectedBodies(
   selected: readonly Selection[],
   e: Emit,
@@ -11425,9 +11465,17 @@ function queueCommentOnlySelectedBodies(
     }
     const owner = e.context?.sourceOwnerForBody?.(def.rules) ?? null;
     if (owner !== null && owner !== e.context?.documentContext) {
-      settledEmission(withSourceOwner(e, owner, () => queueCommentOnlyBody(def, e, group)), def, e);
+      settledEmission(withSourceOwner(e, owner, () => {
+        const comments = bodyBlockCommentTexts(def, e);
+        if (comments.length !== 0) {
+          queueLeafBlockComments(e, group, comments);
+        }
+      }), def, e);
     } else {
-      queueCommentOnlyBody(def, e, group);
+      const comments = bodyBlockCommentTexts(def, e);
+      if (comments.length !== 0) {
+        queueLeafBlockComments(e, group, comments);
+      }
     }
   }
 }
@@ -12198,7 +12246,13 @@ function forItemsFromMixinCall(call: MixinCall, frame: Frame, e: Emit): MaybePro
     pending: [],
     emitBlock: noop
   };
-  return mapMaybe(expandCall(call, null, null, frame, collected, noop, discard, e, false, true), () => {
+  const outerPendingBlockCommentOwner = e.pendingLeafBlockCommentOwner;
+  const outerPendingBlockComments = e.pendingLeafBlockComments;
+  e.pendingLeafBlockCommentOwner = null;
+  e.pendingLeafBlockComments = null;
+  const finish = (): ForItem[] => {
+    e.pendingLeafBlockCommentOwner = outerPendingBlockCommentOwner;
+    e.pendingLeafBlockComments = outerPendingBlockComments;
     const items: ForItem[] = [];
     for (const leaf of collected) {
       const n = leaf.node;
@@ -12210,7 +12264,22 @@ function forItemsFromMixinCall(call: MixinCall, frame: Frame, e: Emit): MaybePro
       }
     }
     return items;
-  });
+  };
+  try {
+    const expanded = expandCall(call, null, null, frame, collected, noop, discard, e, false, true);
+    if (isThenable(expanded)) {
+      return expanded.then(finish, (error) => {
+        e.pendingLeafBlockCommentOwner = outerPendingBlockCommentOwner;
+        e.pendingLeafBlockComments = outerPendingBlockComments;
+        throw error;
+      });
+    }
+    return finish();
+  } catch (error) {
+    e.pendingLeafBlockCommentOwner = outerPendingBlockCommentOwner;
+    e.pendingLeafBlockComments = outerPendingBlockComments;
+    throw error;
+  }
 }
 
 function forItemsFromCollection(node: Collection, frame: Frame | null, e: Emit): ForItem[] {
@@ -12919,7 +12988,15 @@ function substituteClosureVarArgs(
       };
 }
 
-function flushBlock(selector: string[], group: Leaf[], e: Emit, selNode?: SelectorList, parentKey?: object | null, owner?: object): MaybePromise<void> {
+function flushBlock(
+  selector: string[],
+  group: Leaf[],
+  e: Emit,
+  selNode?: SelectorList,
+  parentKey?: object | null,
+  owner?: object,
+  trailingBlockComments: readonly string[] = EMPTY_LEAF_BLOCK_COMMENTS
+): MaybePromise<void> {
   /*
    * A root-level mixin/detached-ruleset call has no selector header. Its ordinary
    * declarations are invalid Less output; custom properties remain legal at root.
@@ -12940,8 +13017,6 @@ function flushBlock(selector: string[], group: Leaf[], e: Emit, selNode?: Select
     }
   }
   const emit = (kept: Leaf[], mergeMode: MergeGroupMode = MERGE_NONE): void => {
-    const trailingBlockComments = takePendingLeafBlockComments(group);
-
     // [atrule] indent by the current block depth (0 at top level == prior behavior).
     const idt = e.depth > 0 ? INDENT.repeat(e.depth) : '';
     const authoredHeader = parentKey === null && selector.length === selNode?.selectors.length
@@ -15087,6 +15162,7 @@ function emitAtRuleBody(
   const ownerBodyStart = owner === undefined ? NO_SPAN : bodyStartOf(owner);
   let bodyTriviaCursor = ownerBodyStart === NO_SPAN ? 0 : ownerBodyStart;
   const flushDirect = (): void => {
+    const trailingBlockComments = takePendingLeafBlockComments(e, group);
     if (group.length > 0) {
       const mergeMode = mergeGroupMode(group);
       if (mergeMode !== MERGE_NONE) {
@@ -15104,6 +15180,12 @@ function emitAtRuleBody(
         }
       }
       group.length = 0;
+    }
+    const indent = INDENT.repeat(e.depth + 1);
+    for (const comment of trailingBlockComments) {
+      put(e, indent);
+      put(e, comment);
+      put(e, '\n');
     }
   };
 
@@ -15146,7 +15228,7 @@ function emitAtRuleBody(
       case 'Comment':
       case 'FunctionCall':
         if (e.referenceImportDepth === 0) {
-          group.push({ node, frame });
+          addLeaf(group, null, evaluatedLeaf(node, frame), false, e);
         }
         return undefined;
       case 'Ruleset':
@@ -15277,13 +15359,16 @@ function emitBubbleBody(
     || statement.type === 'AtRuleStatement');
   const deferredChildren: Array<() => MaybePromise<void>> | null = deferStaticChildren ? [] : null;
   const flushDirect = (): MaybePromise<void> => {
-    if (group.length === 0) {
+    const trailingBlockComments = takePendingLeafBlockComments(e, group);
+    if (group.length === 0 && trailingBlockComments.length === 0) {
       return;
     }
     if (ctx !== null) {
       // Wrap the direct declarations in the propagated selector context.
       e.depth++;
-      const emitted = flushBlock(ctx, group, e);
+      const emitted = flushBlock(
+        ctx, group, e, undefined, undefined, undefined, trailingBlockComments
+      );
       if (isThenable(emitted)) {
         return emitted.then(
           () => {
@@ -15306,6 +15391,12 @@ function emitBubbleBody(
           emitLeaf(leaf, e);
         }
       }
+      const indent = INDENT.repeat(e.depth + 1);
+      for (const comment of trailingBlockComments) {
+        put(e, indent);
+        put(e, comment);
+        put(e, '\n');
+      }
     }
     group.length = 0;
   };
@@ -15323,7 +15414,7 @@ function emitBubbleBody(
         case 'Comment':
         case 'FunctionCall':
           if (e.referenceImportDepth === 0) {
-            group.push({ node, frame });
+            addLeaf(group, null, evaluatedLeaf(node, frame), false, e);
           }
           break;
         case 'Ruleset':
@@ -15767,10 +15858,10 @@ function emitNestedBody(
     bodyTriviaCursor = end === NO_SPAN ? bodyTriviaCursor : end;
   };
   const flushBuf = sharedLeaves?.flush ?? (() => {
-    if (buf.length === 0 && !hasPendingLeafBlockComments(buf)) {
+    if (buf.length === 0 && e.pendingLeafBlockCommentOwner !== buf) {
       return;
     }
-    const trailingBlockComments = takePendingLeafBlockComments(buf);
+    const trailingBlockComments = takePendingLeafBlockComments(e, buf);
     const mergeMode = mergeGroupMode(buf);
     if (mergeMode !== MERGE_NONE) {
       mergeFold(
@@ -15855,6 +15946,17 @@ function emitNestedBody(
     }
     emitTopLevelBlockCommentsBetween(e, rootTriviaCursor, Number.MAX_SAFE_INTEGER, '');
   };
+  const placeLeaf = (leaf: Leaf): void => {
+    const pendingBlockComments = e.pendingLeafBlockCommentOwner === buf
+      ? e.pendingLeafBlockComments
+      : null;
+    if (pendingBlockComments !== null) {
+      e.pendingLeafBlockComments = null;
+      e.pendingLeafBlockCommentOwner = null;
+      leaf.leadingBlockComments = pendingBlockComments;
+    }
+    buf.push(leaf);
+  };
   const run = (start: number): MaybePromise<void> => {
     for (let index = start; index < statements.length; index++) {
       const node = statements[index]!;
@@ -15876,41 +15978,23 @@ function emitNestedBody(
           if (e.referenceImportDepth > 0) {
             break;
           }
-          queueBodyTriviaBefore(bodyTrivia, node, buf, e);
-          const pushLeaf = (leafNode: Declaration | Comment): void => {
-            /*
-             * [property-accessor] Publish the declaration for `$name` lookups
-             * exactly as the collapsed emitter does (its `propertyScope`): a
-             * spliced mixin/apply/loop body publishes into the block that owns
-             * the shared leaf buffer, while its values still evaluate in the
-             * call frame. The nested emitter skipped this, so `height: $width`
-             * was a name-not-found under the v5 default and fine when collapsed.
-             */
-            if (leafNode.type === 'Declaration') {
-              recordPropertyDeclaration(sharedLeaves?.propertyScope ?? frame, leafNode, frame);
-            }
-            const leaf = attachPendingLeafBlockComments(buf, {
-              node: leafNode,
-              frame,
-              ...(imp ? { important: true } : {}),
-              ...(applyExpansion ? { fromApply: true } : {})
-            });
-            buf.push(leaf);
-          };
 
           /*
-           * [nested-property] A property-root `{ … }` block expands to hyphenated
-           * declarations here exactly as in the flattened emitter, so both modes
-           * produce the same declarations — see {@link nestedPropertyDeclarations}.
+           * This is the same evaluator operation used by the collapsed writer:
+           * property publication, nested-property expansion, and Leaf creation
+           * cannot drift with output mode.
            */
-          const parts = node.type === 'Declaration' ? nestedPropertyDeclarations(node, frame, e) : null;
-          if (parts !== null) {
-            for (const part of parts) {
-              pushLeaf(part);
-            }
-            break;
-          }
-          pushLeaf(node);
+          evaluateLeafStatement(
+            node,
+            frame,
+            sharedLeaves?.propertyScope ?? frame,
+            e,
+            imp,
+            applyExpansion,
+            bodyTrivia,
+            buf,
+            placeLeaf
+          );
           break;
         }
         case 'Ruleset': {
@@ -16075,20 +16159,12 @@ function emitNestedBody(
           markAfterRootStatement(node);
           break;
         case 'MixinDefinition':
-          publishSelectedMixinDefinition(frame, node);
-          if (rootTriviaCursor !== undefined) {
+          if (evaluateSilentStatement(node, frame, e) && rootTriviaCursor !== undefined) {
             rootTriviaSuppressedByDefinition = true;
           }
           break;
         case 'VariableDeclaration':
-          activateVariableDeclaration(node, frame, e);
-          markSilentStatementBlockCommentTrivia(node, e);
-          if (
-            rootTriviaCursor !== undefined
-            && !isValueSlotArray(node.value)
-            && 'type' in node.value
-            && isValueBlock(node.value)
-          ) {
+          if (evaluateSilentStatement(node, frame, e) && rootTriviaCursor !== undefined) {
             rootTriviaSuppressedByDefinition = true;
           }
           break;
@@ -16562,7 +16638,7 @@ function emitNestedRuleAuthored(
       if (plan && plan.splits.length > 0) {
         for (const st of rule.rules) {
           if (st.type === 'Declaration' || st.type === 'Comment') {
-            direct.push({ node: st, frame: childFrame });
+            direct.push(evaluatedLeaf(st, childFrame));
           }
         }
       }

--- a/packages/jess/test/less/all-less.test.ts
+++ b/packages/jess/test/less/all-less.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { afterAll, describe, it, expect } from 'vitest';
 import * as glob from 'glob';
 import * as path from 'path';
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
+import { createHash } from 'node:crypto';
 import { invalidLess } from '@jesscss/shared';
 import { Compiler } from '../../src/index.js';
 import { outputDiagnostics } from '@jesscss/compiler/diagnostics';
@@ -91,6 +92,36 @@ const envFixturePattern = process.env.JESS_LESS_FIXTURE;
 const fixtureFilter = envFixturePattern
   ? new RegExp(envFixturePattern)
   : undefined;
+const forceCollapseNesting = process.env.JESS_FORCE_COLLAPSE_NESTING === 'true';
+const manifestOut = process.env.JESS_LESS_MANIFEST_OUT;
+
+type CorpusManifestRecord = {
+  case: string;
+  cssSha256?: string;
+  diagnosticCodes?: string[];
+};
+
+const manifestRecords: CorpusManifestRecord[] = [];
+
+function recordManifest(testCase: string, result: RenderResult): void {
+  if (manifestOut === undefined) {
+    return;
+  }
+  const diagnosticCodes = result.errors.map(diagnostic => diagnostic.code);
+  manifestRecords.push(diagnosticCodes.length === 0
+    ? {
+        case: testCase,
+        cssSha256: createHash('sha256').update(result.css).digest('hex')
+      }
+    : { case: testCase, diagnosticCodes });
+}
+
+afterAll(() => {
+  if (manifestOut !== undefined) {
+    manifestRecords.sort((left, right) => left.case.localeCompare(right.case));
+    writeFileSync(manifestOut, `${JSON.stringify(manifestRecords, null, 2)}\n`, 'utf8');
+  }
+});
 
 const fixtureTimeoutMs = 4500;
 
@@ -445,13 +476,15 @@ describe('Can render Less files to CSS', () => {
               },
               output: {
                 ...baseCompiler.opts.output,
-                ...(testCase.config.output || {})
+                ...(testCase.config.output || {}),
+                ...(forceCollapseNesting ? { collapseNesting: true } : {})
               }
             });
 
             const result = await testCompiler.renderToResult(lessPath, {
               outputFile: testCase.expectedFile
             });
+            recordManifest(`${testName}${configSuffix}`, result);
             return { expectedCss, result };
           };
 

--- a/packages/jess/test/less/reference-mixin-trivia.test.ts
+++ b/packages/jess/test/less/reference-mixin-trivia.test.ts
@@ -21,6 +21,146 @@ const fixtureDir = path.dirname(asyncFixture);
 
 describe('reference mixin trivia', () => {
   it.each([true, false])(
+    'drains root call trivia before the next ruleset (collapse=%s)',
+    async (collapseNesting) => {
+      const source = '.empty() { /* captured root-only */ }\n'
+        + '.empty();\n'
+        + '.a { x: 1; }\n';
+      const compiler = new Compiler({
+        output: { collapseNesting },
+        compile: { plugins: [lessPlugin()] }
+      });
+
+      const result = await compiler.renderToResult({
+        source,
+        language: 'less',
+        extension: '.less'
+      }, {});
+
+      expect(result.errors).toEqual([]);
+      expect(result.css).toBe(
+        '/* captured root-only */\n'
+        + '.a {\n'
+        + '  x: 1;\n'
+        + '}\n'
+      );
+    }
+  );
+
+  it.each([true, false])(
+    'drains direct at-rule call trivia before the next ruleset (collapse=%s)',
+    async (collapseNesting) => {
+      const source = '.empty() { /* captured atrule-only */ }\n'
+        + '@media screen {\n'
+        + '  .empty();\n'
+        + '  .a { x: 1; }\n'
+        + '}\n';
+      const compiler = new Compiler({
+        output: { collapseNesting },
+        compile: { plugins: [lessPlugin()] }
+      });
+
+      const result = await compiler.renderToResult({
+        source,
+        language: 'less',
+        extension: '.less'
+      }, {});
+
+      expect(result.errors).toEqual([]);
+      expect(result.css).toBe(
+        '@media screen {\n'
+        + '  /* captured atrule-only */\n'
+        + '  .a {\n'
+        + '    x: 1;\n'
+        + '  }\n'
+        + '}\n'
+      );
+    }
+  );
+
+  it.each([true, false])(
+    'does not leak trivia from a capture-only each() iterable (collapse=%s)',
+    async (collapseNesting) => {
+      const source = '.m() { a: 1; /* captured tail */ }\n'
+        + 'each(.m(), { .item-@{key} { value: @value; } });\n'
+        + '.after { z: 2; }\n';
+      const compiler = new Compiler({
+        output: { collapseNesting },
+        compile: { plugins: [lessPlugin()] }
+      });
+
+      const result = await compiler.renderToResult({
+        source,
+        language: 'less',
+        extension: '.less'
+      }, {});
+
+      expect(result.errors).toEqual([]);
+      expect(result.css).toBe(
+        '.item-a {\n'
+        + '  value: 1;\n'
+        + '}\n'
+        + '.after {\n'
+        + '  z: 2;\n'
+        + '}\n'
+      );
+    }
+  );
+
+  it.each([
+    [
+      true,
+      '.a {\n'
+      + '  x: 1;\n'
+      + '  /* mixin tail */\n'
+      + '}\n'
+      + '.a .child {\n'
+      + '  y: 2;\n'
+      + '}\n'
+      + '.a {\n'
+      + '  z: 3;\n'
+      + '}\n'
+    ],
+    [
+      false,
+      '.a {\n'
+      + '  x: 1;\n'
+      + '  .child {\n'
+      + '    y: 2;\n'
+      + '  }\n'
+      + '  z: 3;\n'
+      + '  /* mixin tail */\n'
+      + '}\n'
+    ]
+  ] as const)(
+    'keeps a mixin-tail comment with its buffer across a nested boundary (collapse=%s)',
+    async (collapseNesting, expected) => {
+      const source = '.mixin() {\n'
+        + '  z: 3;\n'
+        + '  /* mixin tail */\n'
+        + '}\n'
+        + '.a {\n'
+        + '  x: 1;\n'
+        + '  .child { y: 2; }\n'
+        + '  .mixin();\n'
+        + '}\n';
+      const compiler = new Compiler({
+        output: { collapseNesting },
+        compile: { plugins: [lessPlugin()] }
+      });
+
+      const result = await compiler.renderToResult({
+        source,
+        language: 'less',
+        extension: '.less'
+      }, {});
+
+      expect(result.errors).toEqual([]);
+      expect(result.css).toBe(expected);
+    }
+  );
+
+  it.each([true, false])(
     'replays the selected body comment with collapseNesting=%s',
     async (collapseNesting) => {
       const compiler = new Compiler({

--- a/scripts/measure-less-hotpath.mjs
+++ b/scripts/measure-less-hotpath.mjs
@@ -287,11 +287,10 @@ function formatPercent(value) {
   return `${(value * 100).toFixed(1)}%`;
 }
 
-function getGitCommit() {
+function getGitCommit(cwd) {
   try {
-    const scriptDir = path.dirname(fileURLToPath(import.meta.url));
     return execFileSync('git', ['rev-parse', 'HEAD'], {
-      cwd: path.resolve(scriptDir, '..'),
+      cwd,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore']
     }).trim();
@@ -300,11 +299,20 @@ function getGitCommit() {
   }
 }
 
-function makeRunMeta(options) {
+function packageVersion(root) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')).version;
+  } catch {
+    return undefined;
+  }
+}
+
+function makeRunMeta(options, testData) {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
   return {
     type: 'less-hotpath-run',
     timestamp: new Date().toISOString(),
-    commit: getGitCommit(),
+    commit: getGitCommit(path.resolve(scriptDir, '..')),
     node: process.version,
     platform: process.platform,
     arch: process.arch,
@@ -315,6 +323,9 @@ function makeRunMeta(options) {
     warmup: options.warmup,
     batchSize: options.batchSize,
     collapseNesting: options.collapseNesting,
+    testDataRoot: testData.root,
+    testDataVersion: testData.version,
+    testDataCommit: testData.commit,
     note: options.note || undefined
   };
 }
@@ -334,6 +345,9 @@ function toRecord(run, fixture, result, times, rounds) {
     warmup: run.warmup,
     batchSize: run.batchSize,
     collapseNesting: run.collapseNesting,
+    testDataRoot: run.testDataRoot,
+    testDataVersion: run.testDataVersion,
+    testDataCommit: run.testDataCommit,
     note: run.note,
     summary: result,
     times,
@@ -373,6 +387,20 @@ function compareRecords(currentRecords, baselineRecords, threshold) {
         fixture: record.fixture,
         collapseNesting: record.collapseNesting,
         status: 'missing-baseline'
+      };
+    }
+    const identityFields = ['testDataRoot', 'testDataVersion', 'testDataCommit'];
+    const mismatchedIdentity = identityFields.find(field =>
+      baseline[field] !== undefined && baseline[field] !== record[field]);
+    if (mismatchedIdentity !== undefined) {
+      return {
+        fixture: record.fixture,
+        collapseNesting: record.collapseNesting,
+        baselineCommit: baseline.commit,
+        status: 'corpus-mismatch',
+        mismatchedIdentity,
+        baselineValue: baseline[mismatchedIdentity],
+        currentValue: record[mismatchedIdentity]
       };
     }
     const baselineMedian = baseline.summary.median;
@@ -418,8 +446,13 @@ function writeHistory(file, records) {
 
 const options = parseArgs(process.argv.slice(2));
 const fixtures = options.fixtures;
-const testDataRoot = path.dirname(require.resolve('@less/test-data'));
-const run = makeRunMeta(options);
+const testDataRoot = fs.realpathSync(process.env.JESS_LESS_TEST_DATA_ROOT
+  ?? path.dirname(require.resolve('@less/test-data')));
+const run = makeRunMeta(options, {
+  root: testDataRoot,
+  version: packageVersion(testDataRoot),
+  commit: getGitCommit(testDataRoot)
+});
 
 const compiler = new Compiler({
   output: {
@@ -490,6 +523,7 @@ if (options.json) {
 } else {
   console.log(`Less hot-path measurement (${options.iterations} iterations, ${options.warmup} warmup, ${options.repeat} repeat, batch ${options.batchSize}, ${formatPercent(options.trim)} trim, collapseNesting=${options.collapseNesting})`);
   console.log(`commit=${run.commit ?? 'unknown'} node=${run.node} platform=${run.platform}/${run.arch}`);
+  console.log(`testDataRoot=${run.testDataRoot} testDataVersion=${run.testDataVersion ?? 'unknown'} testDataCommit=${run.testDataCommit ?? 'unknown'}`);
   for (const record of records) {
     const result = record.summary;
     console.log(`${record.fixture}`);
@@ -497,7 +531,9 @@ if (options.json) {
     console.log(`  trimmedMean=${formatMs(result.trimmedMean)} trimmedRsd=${formatPercent(result.trimmedRelativeStdDev)} mad=${formatMs(result.mad)} iqr=${formatMs(result.iqr)}`);
     const compared = comparison.find(item => item.fixture === record.fixture
       && item.collapseNesting === record.collapseNesting);
-    if (compared && compared.status !== 'missing-baseline') {
+    if (compared?.status === 'corpus-mismatch') {
+      console.log(`  corpus mismatch: ${compared.mismatchedIdentity} baseline=${compared.baselineValue} current=${compared.currentValue}`);
+    } else if (compared && compared.status !== 'missing-baseline') {
       console.log(`  vs ${compared.baselineCommit?.slice(0, 8) ?? 'baseline'}: ${formatMs(compared.delta)} (${formatPercent(compared.ratio)}) ${compared.status}`);
     }
   }

--- a/scripts/measure-less-hotpath.mjs
+++ b/scripts/measure-less-hotpath.mjs
@@ -31,6 +31,7 @@ const DEFAULT_STABLE_WARMUP = 20;
 function parseArgs(argv) {
   const options = {
     batchSize: 1,
+    collapseNesting: true,
     compare: undefined,
     compareLatest: false,
     fixtures: [],
@@ -59,6 +60,9 @@ function parseArgs(argv) {
         break;
       case '--compare-latest':
         options.compareLatest = true;
+        break;
+      case '--collapse-nesting':
+        options.collapseNesting = readBoolean(readValue(argv, ++i, arg), arg);
         break;
       case '--fixture':
         options.fixtures.push(readValue(argv, ++i, arg));
@@ -144,6 +148,16 @@ function readFloat(value, name) {
     throw new TypeError(`${name} must be a non-negative number`);
   }
   return number;
+}
+
+function readBoolean(value, name) {
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  throw new TypeError(`${name} must be true or false`);
 }
 
 function summarize(times, trimRatio = 0) {
@@ -300,6 +314,7 @@ function makeRunMeta(options) {
     trim: options.trim,
     warmup: options.warmup,
     batchSize: options.batchSize,
+    collapseNesting: options.collapseNesting,
     note: options.note || undefined
   };
 }
@@ -318,6 +333,7 @@ function toRecord(run, fixture, result, times, rounds) {
     trim: run.trim,
     warmup: run.warmup,
     batchSize: run.batchSize,
+    collapseNesting: run.collapseNesting,
     note: run.note,
     summary: result,
     times,
@@ -339,17 +355,25 @@ function readHistory(file) {
 function latestHistoryByFixture(records) {
   const latest = new Map();
   for (const record of records) {
-    latest.set(record.fixture, record);
+    latest.set(recordKey(record), record);
   }
   return latest;
+}
+
+function recordKey(record) {
+  return `${record.fixture}\0${record.collapseNesting ?? true}`;
 }
 
 function compareRecords(currentRecords, baselineRecords, threshold) {
   const baselineByFixture = latestHistoryByFixture(baselineRecords);
   return currentRecords.map((record) => {
-    const baseline = baselineByFixture.get(record.fixture);
+    const baseline = baselineByFixture.get(recordKey(record));
     if (!baseline) {
-      return { fixture: record.fixture, status: 'missing-baseline' };
+      return {
+        fixture: record.fixture,
+        collapseNesting: record.collapseNesting,
+        status: 'missing-baseline'
+      };
     }
     const baselineMedian = baseline.summary.median;
     const currentMedian = record.summary.median;
@@ -360,6 +384,7 @@ function compareRecords(currentRecords, baselineRecords, threshold) {
     const status = compareStatus(ratio, threshold, baselineSignalQuality, currentSignalQuality);
     return {
       fixture: record.fixture,
+      collapseNesting: record.collapseNesting,
       baselineCommit: baseline.commit,
       baselineMedian,
       currentMedian,
@@ -398,7 +423,7 @@ const run = makeRunMeta(options);
 
 const compiler = new Compiler({
   output: {
-    collapseNesting: true
+    collapseNesting: options.collapseNesting
   },
   compile: {
     plugins: [
@@ -463,14 +488,15 @@ if (options.json) {
     console.log(JSON.stringify(record));
   }
 } else {
-  console.log(`Less hot-path measurement (${options.iterations} iterations, ${options.warmup} warmup, ${options.repeat} repeat, batch ${options.batchSize}, ${formatPercent(options.trim)} trim)`);
+  console.log(`Less hot-path measurement (${options.iterations} iterations, ${options.warmup} warmup, ${options.repeat} repeat, batch ${options.batchSize}, ${formatPercent(options.trim)} trim, collapseNesting=${options.collapseNesting})`);
   console.log(`commit=${run.commit ?? 'unknown'} node=${run.node} platform=${run.platform}/${run.arch}`);
   for (const record of records) {
     const result = record.summary;
     console.log(`${record.fixture}`);
     console.log(`  signal=${result.signalQuality} median=${formatMs(result.median)} mean=${formatMs(result.mean)} sampleMedian=${formatMs(result.sampleMedian)} trimmedMedian=${formatMs(result.trimmedMedian)} p75=${formatMs(result.p75)} p90=${formatMs(result.p90)} min=${formatMs(result.min)} max=${formatMs(result.max)} rsd=${formatPercent(result.relativeStdDev)} roundRsd=${formatPercent(result.roundRelativeStdDev)} outliers=${result.outliers}/${result.samples}`);
     console.log(`  trimmedMean=${formatMs(result.trimmedMean)} trimmedRsd=${formatPercent(result.trimmedRelativeStdDev)} mad=${formatMs(result.mad)} iqr=${formatMs(result.iqr)}`);
-    const compared = comparison.find(item => item.fixture === record.fixture);
+    const compared = comparison.find(item => item.fixture === record.fixture
+      && item.collapseNesting === record.collapseNesting);
     if (compared && compared.status !== 'missing-baseline') {
       console.log(`  vs ${compared.baselineCommit?.slice(0, 8) ?? 'baseline'}: ${formatMs(compared.delta)} (${formatPercent(compared.ratio)}) ${compared.status}`);
     }

--- a/scripts/measure-less-hotpath.mjs
+++ b/scripts/measure-less-hotpath.mjs
@@ -299,6 +299,19 @@ function getGitCommit(cwd) {
   }
 }
 
+function getGitTopLevel(cwd) {
+  try {
+    const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+    return fs.realpathSync(root);
+  } catch {
+    return undefined;
+  }
+}
+
 function packageVersion(root) {
   try {
     return JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')).version;
@@ -446,12 +459,17 @@ function writeHistory(file, records) {
 
 const options = parseArgs(process.argv.slice(2));
 const fixtures = options.fixtures;
+const sourceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const testDataRoot = fs.realpathSync(process.env.JESS_LESS_TEST_DATA_ROOT
   ?? path.dirname(require.resolve('@less/test-data')));
+const sourceGitRoot = getGitTopLevel(sourceRoot);
+const testDataGitRoot = getGitTopLevel(testDataRoot);
 const run = makeRunMeta(options, {
   root: testDataRoot,
   version: packageVersion(testDataRoot),
-  commit: getGitCommit(testDataRoot)
+  commit: testDataGitRoot !== undefined && testDataGitRoot !== sourceGitRoot
+    ? getGitCommit(testDataGitRoot)
+    : undefined
 });
 
 const compiler = new Compiler({


### PR DESCRIPTION
## Summary

Nested and collapsed output now share one evaluation operation for declarations, comments, mixin definitions, and variables. Property accessors and callable-body trivia therefore use the same lookup facts and ownership rules before either writer projects the result.

This is Slice 1 of the V19 one-evaluator cutover planned in #132. Mixin expansion, control flow, hoist/bubbling, and deletion of the second dispatcher remain follow-up slices.

Related: #126

## Design decisions

- Pending callable trivia is short-lived render state on `Emit`: one nullable comment list plus its exact `Leaf[]` owner. This removes the per-buffer `WeakMap` and prevents capture-only or adjacent buffers from consuming each other's trivia.
- Every `Leaf` has the same five-field layout. The shared evaluator constructs declaration/comment leaves directly, so a declaration adds zero net evaluator/writer helper-call rungs.
- Capture-only mixin expansion saves, clears, and restores pending ownership across synchronous completion, asynchronous completion/rejection, and synchronous exceptions.
- `collapseNesting` remains at two writer-selection reads in this slice. Evaluation no longer branches on it for the responsibilities folded here.

`serialize.ts` changes from 17,013 to 17,089 lines. Static hot-path counts are: named functions 421 → 421, arrow sites 585 → 584, `Map` 58 → 58, `Set` 34 → 34, `WeakMap` 7 → 6, leaf-buffer sites 9 → 9, and conditional `Leaf` spreads 5 → 0.

## Behavior

The maintained forced-collapse corpus is byte-identical before and after this slice: 111/111 named records, manifest SHA-256 `ab837140229078bfd56a5ab47fe07dc26ceaf34b339f68e8adab67da4ec5499c`.

Two focused cases intentionally change collapsed output outside that corpus. Comment-only mixin bodies at document root and directly inside an at-rule previously dropped their block comments when collapsed. Both projections now retain those comments at the call-site boundary, as required by V19 and G28.

Negative controls proved the gates see the targeted failures:

- Removing shared property publication failed all 4 focused accessor cases in both modes and changed the `functions`, `property-accessors`, and `property-targeted` corpus records.
- Adding one disposable `WeakMap` failed the source ratchet at 7 versus its ceiling of 6.
- Doubling the evaluator visit counter failed the N=2 probe at 4; N/2N measurements otherwise produced exactly 4/4 and 8/8 evaluator visits/writer callbacks.

## Validation

- Dependency-ordered `pnpm run build:release`: green.
- Required root core gate: 199 files passed / 1 skipped; 3,189 tests passed / 9 skipped / 2 todo.
- Package-local core gate: 209 files and 3,253 tests passed / 8 skipped / 2 todo.
- Jess ratchet: 1,421 tests, with 0 current, gating-baseline, or flaky-baseline failures; pass set exactly matched.
- Normal all-less: 112/112.
- Expanded both-mode selection: 66 passed / 5 todo.
- Property/trivia focused tests: 16/16.
- Dependents: plugin-less 14/14; fns 718/718; plugin-scss 2/2.
- `verify:aggressive-cutting-review`, `check:guardrails`, staged lint, and `git diff --check`: green.

## Performance

`measure:less:hotpath` ran before/after in the same machine session under Node 24.11.1 against Less test-data `5.0.0-alpha.3` at `3af87fc036f6b2c23d27eb48461bbfc4ef3db6c4`. Medians are milliseconds.

| Mode | Fixture | Before | After | Same-commit null |
| --- | --- | ---: | ---: | ---: |
| collapsed | functions | 4.16 | 4.45 | 4.33 |
| collapsed | import-reference | 7.31 | 8.78 | 7.03 |
| collapsed | mixins-guards | 4.72 | 4.62 | 4.51 |
| collapsed | extend-chaining | 1.07 | 1.23 | 1.09 |
| collapsed | media | 1.56 | 1.65 | 1.51 |
| nested | functions | 4.60 | 3.99 | 4.13 |
| nested | import-reference | 6.85 | 6.90 | 6.61 |
| nested | mixins-guards | 4.55 | 4.65 | 4.50 |
| nested | extend-chaining | 1.16 | 1.11 | 1.20 |
| nested | media | 1.44 | 1.47 | 1.61 |

Same-commit null drift ranged from -19.9% to +9.5%, so these timings are inconclusive and support no speed or neutrality claim. A disposable 10,000-iteration evaluator control moved the functions median from 4.33 to 18.34 ms collapsed and from 4.13 to 18.19 ms nested, proving the harness can detect a material regression.

## Review findings addressed

- Replaced render-wide and weak side-table trivia ownership with exact buffer ownership on the existing context.
- Covered root, at-rule, bubble, nested, and capture-only lifetimes, including exceptional and asynchronous restoration.
- Added corpus path, package version, and Git commit provenance to benchmark records while preserving legacy history matching.
- Removed the added declaration helper rung and documented all bounded positive-comment emission loops.

The semantics reviewer approved all eight invariants under V19/G28. The performance-architecture reviewer approved invariants 1–11 and incidents R1–R8 with no remaining blocker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved comment and trivia handling across nested rules, mixins, imports, loops, conditionals, and at-rules.
  - Preserved comment ownership and source order across asynchronous and imported-document boundaries.
  - Prevented trivia from leaking between captured iterables and ensured mixin-tail comments remain correctly attached.

- **Documentation**
  - Updated evaluator architecture and hot-path benchmarking documentation.
  - Documented nesting-collapse options, benchmark metadata, and history comparison behavior.

- **Tests**
  - Added coverage to verify comment handling in both nesting-collapse modes.
  - Added safeguards for consistent serializer behavior and output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->