### PR TITLE
refactor(core): share callable evaluation

### DIFF
--- a/docs/architecture/core/HANDOFF.md
+++ b/docs/architecture/core/HANDOFF.md
@@ -4095,7 +4095,7 @@ involved.
   aggressive-cutting, touched-file lint, and diff-check pass. Shape stability retains
   the target branch's stale AST corpus inventory/`SpacedValue` allowlist failures;
   its monomorphic-node assertion and all five CST checks pass. Static counts are
-  `serialize.ts` 17,089 to 16,988 lines, Map 58 to 57, Set 34 to 34, WeakMap 6 to 5,
+  `serialize.ts` 17,089 to 16,993 lines, Map 58 to 57, Set 34 to 34, WeakMap 6 to 5,
   Frame construction sites 30 to 28, Leaf groups 9 to 9, and evaluator-side
   `e.collapse` reads 2 to 2.
 - Boundary evidence: no public type/export changes. Semantics review approves all eight
@@ -4129,7 +4129,7 @@ involved.
     "why": "SETTLED V19 makes evaluation and lookup functions of the source stylesheet, independent of nesting output. Slice 2 deletes three nested-only callable evaluators and sends their one shared evaluated activation directly to the existing collapsed or nested writer.",
     "dangerTokensJustification": "The final projection choice is an allocation-free branch on the already-live nested leaf context and calls the existing writer directly. Selected bodies retain a synchronous for loop. The removed render-global WeakMap becomes the existing BindingCell.valueFrame initialized in its existing four-field shape. The rare MixinCall-only previous-cell walk is bounded by distinct same-name declarations and N/2N instrumentation measured 20 to 40 steps for 4 to 8 self-copying activations in both modes.",
     "behaviorEvidence": "Focused callable and diagnostic suites pass. N/2N and doubled-write probes are sensitive; leak removal changes two named forced-collapse records; source-node perturbation changes the pinned diagnostic column in both modes.",
-    "buildEvidence": "Dependency-order build passes. Core passes 3194 tests; Jess ratchet passes 1423 with empty current/gating/flaky failure sets; all-less passes 112/112; the 111-record forced-collapse manifests are identical; selected both-mode Jess tests pass 73/73; dependents pass 14/14, 718/718, and 2/2. Guardrails, aggressive-cutting, touched-file lint, and diff-check pass. Shape stability retains the target branch's stale AST inventory/SpacedValue allowlist failures while its monomorphic-node and all CST assertions pass. Static counts: lines 17089 to 16988, named functions 421 to 418, arrows 605 to 583, Map 58 to 57, Set 34 unchanged, WeakMap 6 to 5, Frame construction sites 30 to 28. Same-session hot-path timings are reported separately and carry no speed claim.",
+    "buildEvidence": "Dependency-order build passes. Core passes 3194 tests; Jess ratchet passes 1423 with empty current/gating/flaky failure sets; all-less passes 112/112; the 111-record forced-collapse manifests are identical; selected both-mode Jess tests pass 73/73; dependents pass 14/14, 718/718, and 2/2. Guardrails, aggressive-cutting, touched-file lint, and diff-check pass. Shape stability retains the target branch's stale AST inventory/SpacedValue allowlist failures while its monomorphic-node and all CST assertions pass. Static counts: lines 17089 to 16993, named functions 421 to 418, arrows 605 to 583, Map 58 to 57, Set 34 unchanged, WeakMap 6 to 5, Frame construction sites 30 to 28. Same-session hot-path timings are reported separately and carry no speed claim.",
     "baseline": {
       "fixture": "benchmark.less",
       "phase": "render",

--- a/docs/architecture/core/HANDOFF.md
+++ b/docs/architecture/core/HANDOFF.md
@@ -4028,7 +4028,124 @@ involved.
 
 ## Aggressive Cutting Self-Prosecution
 
-- Latest pass: 2026-09-03 V19 slice 1 shared lookup and leaf bookkeeping. This
+- Latest pass: 2026-09-03 V19 slice 2 shared callable expansion. This folds mixin,
+  `$apply`, and detached-reference selection/evaluation while retaining the two
+  existing streaming writers; it makes no speed claim.
+- Architecture surface: `serialize.ts` callable lookup and dispatch, activation
+  frames, argument closure ownership, plugin preparation, recursion accounting,
+  scope publication, body-trivia replay, diagnostics, and the collapsed/nested
+  writer boundary. Parser grammar, canonical node schemas, public package APIs,
+  selector composition, at-rule bubbling, and output-option ownership are unchanged.
+- Separation/duplication: `expandNestedCall`, `expandNestedApply`, and
+  `expandNestedReferenceCall` are deleted. `expandCall`, `expandApply`, and
+  `expandReferenceCall` each select and evaluate once, then directly enter
+  `walkBody` or `emitNestedBody` according to the already-live nested leaf context.
+  The projection branch allocates no carrier and adds no callback/helper rung.
+- Cumulative node weight: canonical AST/CST nodes and Frame fields gain zero fields.
+  Mixin-call argument homes move from one render-global `WeakMap` to the existing
+  per-activation `BindingCell.valueFrame` slot. Owner-aware cells are constructed in
+  the pre-existing four-field order; no late property transition is introduced.
+- New traversal: no AST/source traversal. Selected bodies use one synchronous `for`
+  loop and recurse only when an existing async body suspends. The only new chain walk
+  runs after an O(1) name lookup, only when the winning binding is a `MixinCall`, and
+  is bounded by distinct self-reading same-name declarations rather than render
+  iterations. Temporary instrumentation with one self-copy per activation measured
+  N=4 as 8 evaluator entries, 8 body writes, 4 owner-aware cells, and 20 bounded cell
+  steps; 2N=8 measured 16/16/8/40 in both projections. Doubling the body-write counter
+  failed at 16 versus the asserted 8.
+- New node/materialization: zero AST/CST nodes, retained evaluated trees, projection
+  wrappers, group arrays, Sets, or per-entry event objects. Static `Map` constructions
+  fall 58 to 57 and `WeakMap` constructions fall 6 to 5. The removed WeakMap is not
+  replaced by a Frame/context map; the already-allocated parameter cell carries its
+  lexical owner for the activation lifetime.
+- Render path: both projections still stream into `Emit.chunks`. Callable selection,
+  frames, captured argument ownership, plugins, leakage, and publication are shared;
+  only the final direct body-writer call differs. Body trivia is acquired inside the
+  selected definition's source-owner scope. Collapsed output drains its tail after
+  `walkBody`; nested output retains `emitNestedBody`'s existing ownership.
+- Helper/API surface: private serializer machinery only. Named functions fall 421 to
+  418, raw arrow sites 605 to 583, `mapMaybe` sites 135 to 126, and `.then` sites 108
+  to 106. One selected callable body has no added writer callback, adapter, closure,
+  or helper-call rung. Frame construction sites fall 30 to 28.
+- Metadata mutations: only existing activation-local Frame/BindingCell state mutates.
+  Canonical source nodes, public results, and parser trivia remain immutable. The
+  call-alias loop now uses the existing exclusion set while following a self-copy so
+  it reaches the prior parameter cell instead of selecting itself indefinitely.
+- Review-flagged diff tokens: [side map] the render-global mixin-call-home WeakMap is
+  deleted; [object shape] owner-aware BindingCells use the existing four-field literal
+  order and no Frame field is added; [loop/traversal] the selected-body sync path is
+  iterative, while the rare MixinCall cell-chain scan is declaration-bounded and
+  measured above; [helper-call] the first callback/adapter version was rejected and
+  removed, leaving direct writer calls; [routine error control] no Error allocation or
+  exception was added for ordinary control flow; [source scan/reparse] none.
+- Behavior evidence: focused callable tests pass 35/35 and public diagnostic tests pass
+  27/27. The same canonical call-valued argument is reused in two caller frames and
+  resolves red then green in both projections, including a same-name self-copy. A
+  disposable removal of shared `leakBodyVars` failed the named both-mode publication
+  test and changed forced-collapse manifest records `namespacing-4` and `scope`; a
+  disposable diagnostic-source perturbation changed both expected columns 10 to 1.
+- Build evidence: dependency-ordered `pnpm run build:release` passes. Root core passes
+  200 files / 3,194 tests / 8 skipped / 2 todo. Jess ratchet passes 1,423 tests with
+  zero current, gating-baseline, or flaky-baseline failures; normal all-less passes
+  112/112. The forced-collapse before/after manifests contain the same 111 named
+  records and identical SHA-256
+  `f45fdeeb52bf1e000dba6c9fdd953de3ceabff1ed6ebccb522c890072ed9dc6c`.
+  The selected both-mode Jess files pass 73/73, including property accessors 4/4.
+  Dependents pass plugin-less 14/14, fns 718/718, and plugin-scss 2/2. Guardrails,
+  aggressive-cutting, touched-file lint, and diff-check pass. Shape stability retains
+  the target branch's stale AST corpus inventory/`SpacedValue` allowlist failures;
+  its monomorphic-node assertion and all five CST checks pass. Static counts are
+  `serialize.ts` 17,089 to 16,988 lines, Map 58 to 57, Set 34 to 34, WeakMap 6 to 5,
+  Frame construction sites 30 to 28, Leaf groups 9 to 9, and evaluator-side
+  `e.collapse` reads 2 to 2.
+- Boundary evidence: no public type/export changes. Semantics review approves all eight
+  invariants under SETTLED V19 after importance, diagnostic-position, closure, and
+  source-owner findings were fixed. Performance review found no code-level blocker
+  after the callback rung, recursive sync loop, late BindingCell transition, and
+  unbounded-lookup concerns were removed or bounded; final approval is tied to this
+  evidence block and the clean gates.
+- Hot-path cost contracts:
+```json
+[
+  {
+    "id": "ast-semantic-runtime-cutover",
+    "verdict": "accepted",
+    "performanceClaim": "none",
+    "owner": "the canonical AST-v2 evaluator/value/extend owners listed by ast-semantic-runtime-cutover",
+    "cases": [
+      "ValueSlot-array-evaluation-and-authored-layout",
+      "List-value-separator-and-Block-delimiter-facts",
+      "reference-index-and-For-array-access",
+      "Less-lazy-color-call-demand-boundary",
+      "defineFunction-typed-positional-named-and-lazy-binding",
+      "mixin-dispatch-ValueSlot-argument-resolution",
+      "ValueLayout-provenance-side-table",
+      "preserve-mode-calc-result-composition",
+      "extend-composition-plan-and-fixpoint-solve",
+      "Less-eager-bare-slash-precedence-and-parens-division",
+      "recursive-ValueGroup-final-unit-validation",
+      "async-declaration-dedup-output-order"
+    ],
+    "why": "SETTLED V19 makes evaluation and lookup functions of the source stylesheet, independent of nesting output. Slice 2 deletes three nested-only callable evaluators and sends their one shared evaluated activation directly to the existing collapsed or nested writer.",
+    "dangerTokensJustification": "The final projection choice is an allocation-free branch on the already-live nested leaf context and calls the existing writer directly. Selected bodies retain a synchronous for loop. The removed render-global WeakMap becomes the existing BindingCell.valueFrame initialized in its existing four-field shape. The rare MixinCall-only previous-cell walk is bounded by distinct same-name declarations and N/2N instrumentation measured 20 to 40 steps for 4 to 8 self-copying activations in both modes.",
+    "behaviorEvidence": "Focused callable and diagnostic suites pass. N/2N and doubled-write probes are sensitive; leak removal changes two named forced-collapse records; source-node perturbation changes the pinned diagnostic column in both modes.",
+    "buildEvidence": "Dependency-order build passes. Core passes 3194 tests; Jess ratchet passes 1423 with empty current/gating/flaky failure sets; all-less passes 112/112; the 111-record forced-collapse manifests are identical; selected both-mode Jess tests pass 73/73; dependents pass 14/14, 718/718, and 2/2. Guardrails, aggressive-cutting, touched-file lint, and diff-check pass. Shape stability retains the target branch's stale AST inventory/SpacedValue allowlist failures while its monomorphic-node and all CST assertions pass. Static counts: lines 17089 to 16988, named functions 421 to 418, arrows 605 to 583, Map 58 to 57, Set 34 unchanged, WeakMap 6 to 5, Frame construction sites 30 to 28. Same-session hot-path timings are reported separately and carry no speed claim.",
+    "baseline": {
+      "fixture": "benchmark.less",
+      "phase": "render",
+      "currentMedianMs": 47.37,
+      "outputSha256": "2b8d9abf3c103a6de7a0a5d66b3a448bcaef8c1818eff753de52d25a23b98f7d",
+      "outputBytes": 122568
+    }
+  }
+]
+```
+- Verdict: accepted as the smallest V19 callable-evaluator fold after the writer
+  callback rung, sync-recursion, source-owner, importance, diagnostic-position, and
+  call-valued closure findings were addressed. Timing remains explicitly inconclusive
+  until the committed same-session harness is recorded.
+
+- Previous pass: 2026-09-03 V19 slice 1 shared lookup and leaf bookkeeping. This
   is the first evaluator-fold slice and a correctness correction with no speed claim.
 - Architecture surface: `serialize.ts` declaration/comment evaluation, property
   publication, callable-body trivia ownership, the existing render `Emit` context,

--- a/packages/core/src/ast/__tests__/detached-ruleset-direct-acceptance.test.ts
+++ b/packages/core/src/ast/__tests__/detached-ruleset-direct-acceptance.test.ts
@@ -8,7 +8,8 @@ import { serialize } from '../serialize.js';
 import { makeLessRegistry } from '@jesscss/fns';
 
 const evaluator = buildEvaluator(makeLessRegistry());
-const render = (document: Stylesheet): string | undefined => serialize(document, { evaluator }).css;
+const render = (document: Stylesheet, collapseNesting = true): string | undefined =>
+  serialize(document, { evaluator, collapseNesting }).css;
 
 describe('variable-call canonical AST emission', () => {
   it('splices a direct detached ruleset through its definition scope and caller fallback', () => {
@@ -58,5 +59,21 @@ describe('variable-call canonical AST emission', () => {
     ]);
 
     expect(render(document)).toBe('.entry .inner {\n  width: 1px;\n}\n');
+    expect(render(document, false)).toBe('.entry {\n  .inner {\n    width: 1px;\n  }\n}\n');
+  });
+
+  it('inherits mixin-call importance through a detached-ruleset reference in both modes', () => {
+    const importantOuter = { ...mixinCall('.outer'), important: true };
+    const document = stylesheet([
+      variableDeclaration('theme', anonymousMixin([decl('color', keyword('red'))]), { mode: 'declare' }),
+      mixinDef('.outer', [], [
+        reference(variableReference('theme', 'scoped'), [{ type: 'Call', args: [] }], '@theme()')
+      ]),
+      rule('.entry', [importantOuter])
+    ]);
+    const expected = '.entry {\n  color: red !important;\n}\n';
+
+    expect(render(document)).toBe(expected);
+    expect(render(document, false)).toBe(expected);
   });
 });

--- a/packages/core/src/ast/__tests__/mixin-direct-acceptance.test.ts
+++ b/packages/core/src/ast/__tests__/mixin-direct-acceptance.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { makeLessRegistry } from '@jesscss/fns';
 import { buildEvaluator } from '../evaluator.js';
 import { cssBaseMathOutsideParens,
-  compoundSelectorOf, complexSelector, decl, dimension, funcCall, interpolatedSimpleSelector, interpolation, keyword, operation, quoted, selist, spaced, stylesheet, rule, variableDeclaration, variableReference,
+  apply, compoundSelectorOf, complexSelector, decl, dimension, funcCall, interpolatedSimpleSelector, interpolation, keyword, operation, quoted, reference, selist, simpleSelector, spaced, stylesheet, rule, variableDeclaration, variableReference,
   type MixinCall, type MixinDefinition, type Stylesheet, type Statement
 } from '../nodes.js';
 import { serialize } from '../serialize.js';
@@ -272,7 +272,34 @@ describe('Mixin canonical AST emission', () => {
       rule('.out', [decl('width', variableReference('shared', 'scoped'))])
     ]);
 
-    expect(render(document)).toBe('.out {\n  width: 7px;\n}\n');
+    const expected = '.out {\n  width: 7px;\n}\n';
+    expect(render(document)).toBe(expected);
+    expect(render(document, false)).toBe(expected);
+  });
+
+  it('retains a mixin-call argument\'s caller closure in both output modes', () => {
+    const paintCall = call('.paint', [{ value: variableReference('color', 'scoped') }]);
+    const forwardCall = call('.forward', [{ value: paintCall }]);
+    const document = stylesheet([
+      mixin('.paint', [{ name: 'value' }], [decl('color', variableReference('value', 'scoped'))]),
+      mixin('.forward', [{ name: 'call' }], [
+        variableDeclaration('color', keyword('blue'), { mode: 'declare' }),
+        variableDeclaration('call', variableReference('call', 'scoped'), { mode: 'declare' }),
+        reference(variableReference('call', 'scoped'), [{ type: 'Call', args: [] }], '@call()')
+      ]),
+      rule('.first', [
+        variableDeclaration('color', keyword('red'), { mode: 'declare' }),
+        forwardCall
+      ]),
+      rule('.second', [
+        variableDeclaration('color', keyword('green'), { mode: 'declare' }),
+        forwardCall
+      ])
+    ]);
+    const expected = '.first {\n  color: red;\n}\n.second {\n  color: green;\n}\n';
+
+    expect(render(document)).toBe(expected);
+    expect(render(document, false)).toBe(expected);
   });
 
   it('places one shared mixin body correctly in flat and nested output modes', () => {
@@ -285,6 +312,23 @@ describe('Mixin canonical AST emission', () => {
     expect(render(document)).toBe('.outer {\n  color: red;\n}\n'
       + '.outer .inner {\n  width: 1px;\n}\n');
     expect(render(document, false)).toBe('.outer {\n  color: red;\n  .inner {\n    width: 1px;\n  }\n}\n');
+  });
+
+  it('places one selected $apply body through both output projections', () => {
+    const document = stylesheet([
+      rule('.paint', [
+        decl('color', keyword('red')),
+        rule('.shade', [decl('opacity', dimension(0.5))])
+      ]),
+      rule('.host', [apply([simpleSelector('.paint')])])
+    ]);
+
+    expect(render(document)).toBe('.paint {\n  color: red;\n}\n'
+      + '.paint .shade {\n  opacity: 0.5;\n}\n'
+      + '.host {\n  color: red;\n}\n'
+      + '.host .shade {\n  opacity: 0.5;\n}\n');
+    expect(render(document, false)).toBe('.paint {\n  color: red;\n  .shade {\n    opacity: 0.5;\n  }\n}\n'
+      + '.host {\n  color: red;\n  .shade {\n    opacity: 0.5;\n  }\n}\n');
   });
 
   it('projects only a selected ruleset-mixin ampersand header in nested output', () => {

--- a/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
+++ b/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
@@ -50,4 +50,16 @@ describe('V19 one-evaluator projection ratchet', () => {
     expect(occurrences(/evaluateLeafStatement\(/gu)).toBe(3);
     expect(occurrences(/evaluateSilentStatement\(/gu)).toBe(5);
   });
+
+  it('pins the duplicate callable-expansion surface before slice 2', () => {
+    expect(occurrences(/function expandCall\(/gu)).toBe(1);
+    expect(occurrences(/function expandApply\(/gu)).toBe(1);
+    expect(occurrences(/function expandReferenceCall\(/gu)).toBe(1);
+    expect(occurrences(/function expandNestedCall\(/gu)).toBe(1);
+    expect(occurrences(/function expandNestedApply\(/gu)).toBe(1);
+    expect(occurrences(/function expandNestedReferenceCall\(/gu)).toBe(1);
+    expect(occurrences(/expandNestedCall\(/gu)).toBe(3);
+    expect(occurrences(/expandNestedApply\(/gu)).toBe(2);
+    expect(occurrences(/expandNestedReferenceCall\(/gu)).toBe(2);
+  });
 });

--- a/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
+++ b/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
@@ -62,5 +62,7 @@ describe('V19 one-evaluator projection ratchet', () => {
     expect(occurrences(/writeCollapsedCallableBody/gu)).toBe(0);
     expect(occurrences(/writeNestedCallableBody/gu)).toBe(0);
     expect(occurrences(/mixinCallHomes/gu)).toBe(0);
+    expect(SOURCE).toContain('const aliasWasExcluded = e.excluded.has(alias);');
+    expect(SOURCE).toContain('if (!aliasWasExcluded) {\n            e.excluded.delete(alias);\n          }');
   });
 });

--- a/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
+++ b/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
@@ -41,25 +41,26 @@ describe('V19 one-evaluator projection ratchet', () => {
   });
 
   it('does not grow the serializer helper or collection-construction surface', () => {
-    expect(occurrences(/^function |^async function /gmu)).toBe(421);
-    expect(occurrences(/new Map/gu)).toBe(58);
+    expect(occurrences(/^function |^async function /gmu)).toBe(418);
+    expect(occurrences(/new Map/gu)).toBe(57);
     expect(occurrences(/new Set/gu)).toBe(34);
-    expect(occurrences(/new WeakMap/gu)).toBe(6);
+    expect(occurrences(/new WeakMap/gu)).toBe(5);
     expect(occurrences(/const group: Leaf\[\] = \[\]/gu)).toBe(9);
     expect(occurrences(/const buf = .*\?\? \[\]/gu)).toBe(1);
     expect(occurrences(/evaluateLeafStatement\(/gu)).toBe(3);
     expect(occurrences(/evaluateSilentStatement\(/gu)).toBe(5);
   });
 
-  it('pins the duplicate callable-expansion surface before slice 2', () => {
+  it('keeps one evaluator for callable expansion', () => {
     expect(occurrences(/function expandCall\(/gu)).toBe(1);
     expect(occurrences(/function expandApply\(/gu)).toBe(1);
     expect(occurrences(/function expandReferenceCall\(/gu)).toBe(1);
-    expect(occurrences(/function expandNestedCall\(/gu)).toBe(1);
-    expect(occurrences(/function expandNestedApply\(/gu)).toBe(1);
-    expect(occurrences(/function expandNestedReferenceCall\(/gu)).toBe(1);
-    expect(occurrences(/expandNestedCall\(/gu)).toBe(3);
-    expect(occurrences(/expandNestedApply\(/gu)).toBe(2);
-    expect(occurrences(/expandNestedReferenceCall\(/gu)).toBe(2);
+    expect(occurrences(/expandNestedCall\(/gu)).toBe(0);
+    expect(occurrences(/expandNestedApply\(/gu)).toBe(0);
+    expect(occurrences(/expandNestedReferenceCall\(/gu)).toBe(0);
+    expect(occurrences(/CallableBodyWriter/gu)).toBe(0);
+    expect(occurrences(/writeCollapsedCallableBody/gu)).toBe(0);
+    expect(occurrences(/writeNestedCallableBody/gu)).toBe(0);
+    expect(occurrences(/mixinCallHomes/gu)).toBe(0);
   });
 });

--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -704,7 +704,7 @@ export interface Frame {
    * never stored on AST nodes. */
   detachedBindings?: Map<ValueBlock, DetachedBinding>;
 
-  /** Per-activation value owners for synthetic parameter declarations. */
+  /** Per-activation lexical owners for values carried by parameter declarations. */
   bindingValueFrames?: Map<Binding, Frame>;
 
   /** Typed URL-bearing values for eager byte snapshots owned by this activation. */
@@ -1044,10 +1044,13 @@ function collectSelectedDeclIndex(
   return byName.size === 0 ? null : { byName };
 }
 
-/** Seed one activation's live cells from mixin/function parameters. */
+/** Seed one activation's live cells from mixin/function parameters.
+ * A call-valued argument keeps its caller on the existing `valueFrame` slot;
+ * constructing the four-field cell here avoids a later hidden-class transition. */
 function cellsForParams(
   params: Map<string, Binding> | null,
-  valueFrames?: ReadonlyMap<Binding, Frame>
+  valueFrames?: ReadonlyMap<Binding, Frame>,
+  mixinCallFrame?: Frame
 ): Map<string, BindingCell> | null {
   if (!params) {
     return null;
@@ -1055,7 +1058,8 @@ function cellsForParams(
   const cells = new Map<string, BindingCell>();
   for (const [name, value] of params) {
     const declaration = variableDeclaration(name, value, { mode: 'declare' });
-    const valueFrame = valueFrames?.get(value);
+    const valueFrame = valueFrames?.get(value)
+      ?? (!isValueSlotArray(value) && value.type === 'MixinCall' ? mixinCallFrame : undefined);
     cells.set(name, valueFrame
       ? { declaration, value, valueFrame, prev: null }
       : { declaration, value, prev: null });
@@ -2264,6 +2268,16 @@ function lookupScopedBinding(frame: Frame | null, name: string, e?: EvalCtx): { 
           continue;
         }
         if (!e?.excluded.has(declaration.value)) {
+          if (!isValueSlotArray(declaration.value) && declaration.value.type === 'MixinCall') {
+            /* A self-reading redeclaration can sit ahead of the synthetic
+             * parameter cell. This rare branch is bounded by distinct
+             * same-name declarations, never by render iteration count. */
+            for (let cell: BindingCell | null | undefined = f.cells?.get(name); cell; cell = cell.prev) {
+              if (cell.value === declaration.value && cell.valueFrame) {
+                return { value: declaration.value, frame: cell.valueFrame };
+              }
+            }
+          }
           return { value: declaration.value, frame: f.bindingValueFrames?.get(declaration.value) ?? f };
         }
       }
@@ -2881,8 +2895,6 @@ interface EvalCtx {
   /* Non-URL structure is visible only at function/plugin argument boundaries. */
   mixinValueBindings: Map<Binding, ValueGroup> | null;
 
-  /** Runtime-only lexical homes for mixin calls carried through an argument. */
-  mixinCallHomes?: WeakMap<MixinCall, Frame>;
 }
 
 /** Force an internal eval value to a typed value node/group. A computed STRING carries no parse
@@ -4821,7 +4833,15 @@ function resolveReferenceResult(
           if (typeof value.name !== 'string') {
             break;
           }
-          const aliased = resolveVarRef(valueFrame, value.name, value.scope, e);
+          const name = value.name;
+          const scope = value.scope;
+
+          /* Exclude the alias currently being followed so `@call: @call`
+           * reaches its prior parameter binding instead of selecting itself. */
+          const alias = value;
+          e.excluded.add(alias);
+          const aliased = resolveVarRef(valueFrame, name, scope, e);
+          e.excluded.delete(alias);
           if (!aliased) {
             break;
           }
@@ -10752,7 +10772,7 @@ function walkBody(
       }
       case 'Reference':
         {
-          const expanded = expandReferenceCall(node, composed, ancestor, frame, group, flush, partition, e, forceLeading, propertyScope, applyExpansion);
+          const expanded = expandReferenceCall(node, composed, ancestor, frame, group, flush, partition, e, imp, forceLeading, propertyScope, applyExpansion);
           if (isThenable(expanded)) {
             return expanded.then(() => walkBody(
               statements.slice(index + 1), composed, ancestor, frame, group, flush,
@@ -11229,7 +11249,9 @@ function expandCall(
   forceLeading = false, // [partition] inherited leading-hoist context
   captureFrames?: Frame[], // [namespace-accessor] collect each callee's callFrame
   propertyScope: Frame = frame, // caller scope receiving spliced declarations
-  applyExpansion = false
+  applyExpansion = false,
+  source: NestedHeaderSource | null = null,
+  sharedLeaves?: NestedLeafBuffer
 ): MaybePromise<void> {
   /*
    * A namespaced/compound call (`#ns .a .b()`, `.jo.ki()`, `.amp.support()`)
@@ -11313,75 +11335,88 @@ function expandCall(
         throw new RangeError('maximum mixin recursion depth exceeded');
       }
       e.mixinDepth++;
-      const finish = (): void => {
-        e.mixinDepth--;
-      };
-      const expandSelected = (index: number): MaybePromise<void> => {
-        if (index >= selected.length) {
-          return;
-        }
-        const { def, bindings, boundSourceKeys } = selected[index]!;
+      const run = (start: number): MaybePromise<void> => {
+        for (let index = start; index < selected.length; index++) {
+          const { def, bindings, boundSourceKeys } = selected[index]!;
 
-        /*
-         * [closure] free variables resolve in the mixin's DEFINITION scope FIRST, with
-         * the call-site scope as a fallback — less@4 evaluates a mixin body under
-         * `definitionFrames.concat(callerFrames)`. `parent` = the definition frame (so
-         * a `@var` written in the mixin's home scope wins over a same-name caller var,
-         * e.g. `mixins-closure`); `fallback` = the caller chain, which also keeps the
-         * DYNAMIC expansion stack reachable for the ruleset-mixin parent-exclusion
-         * check (`parentExcludes`) and lets the body see caller-published mixins. A
-         * namespaced call already descends to the definition scope (home is confined
-         * to the namespace), so it takes no caller fallback.
-        */
-        const homeFrame = homes.get(def) ?? frame;
-        const callFrame: Frame = {
-          parent: homeFrame,
-          mixins: collectMixins(def.rules),
-          declIndex: collectDeclIndex(def.rules, bindings), cells: cellsForParams(bindings), reassign: null,
-          statements: def.rules,
-          sourceOwner: sourceOwnerForBody(def.rules, frame, e),
-          mixinUrlBindings: undefined,
-          mixinValueBindings: undefined,
-          ...(namespaced || homeFrame === frame ? {} : { fallback: frame })
-        };
-        takeMixinValueBindings(boundSourceKeys, e, callFrame);
-        captureArgDefFrames(bindings, frame, callFrame, e);
+          /*
+           * [closure] free variables resolve in the mixin's DEFINITION scope FIRST, with
+           * the call-site scope as a fallback — less@4 evaluates a mixin body under
+           * `definitionFrames.concat(callerFrames)`. `parent` = the definition frame (so
+           * a `@var` written in the mixin's home scope wins over a same-name caller var,
+           * e.g. `mixins-closure`); `fallback` = the caller chain, which also keeps the
+           * DYNAMIC expansion stack reachable for the ruleset-mixin parent-exclusion
+           * check (`parentExcludes`) and lets the body see caller-published mixins. A
+           * namespaced call already descends to the definition scope (home is confined
+           * to the namespace), so it takes no caller fallback.
+           */
+          const homeFrame = homes.get(def) ?? frame;
+          const callFrame: Frame = {
+            parent: homeFrame,
+            mixins: collectMixins(def.rules),
+            declIndex: collectDeclIndex(def.rules, bindings), cells: cellsForParams(bindings, undefined, frame), reassign: null,
+            statements: def.rules,
+            sourceOwner: sourceOwnerForBody(def.rules, frame, e),
+            mixinUrlBindings: undefined,
+            mixinValueBindings: undefined,
+            ...(namespaced || homeFrame === frame ? {} : { fallback: frame })
+          };
+          takeMixinValueBindings(boundSourceKeys, e, callFrame);
+          captureArgDefFrames(bindings, frame, callFrame);
 
-        /*
-         * [namespace-accessor] expose the callee's evaluated scope so a `#ns.m[@var]`
-         * accessor can read its VARIABLE members (local `@x:` decls + nested-call
-         * leaked vars), which never appear in the emitted-declaration output.
-         */
-        captureFrames?.push(callFrame);
+          /*
+           * [namespace-accessor] expose the callee's evaluated scope so a `#ns.m[@var]`
+           * accessor can read its VARIABLE members (local `@x:` decls + nested-call
+           * leaked vars), which never appear in the emitted-declaration output.
+           */
+          captureFrames?.push(callFrame);
 
-        /*
-         * Only an argument-bearing mixin is a transparent parametric wrapper for
-         * this output rule. A zero-parameter `MixinDefinition` splices at its call site;
-         * treating every AST MixinDefinition as force-leading moved `.mixin2()` output
-         * ahead of an intervening nested rule in the Less property-accessor corpus.
-         */
-        const bodyForceLeading = forceLeading || def.params.length !== 0;
+          /*
+           * Only an argument-bearing mixin is a transparent parametric wrapper for
+           * this output rule. A zero-parameter `MixinDefinition` splices at its call site;
+           * treating every AST MixinDefinition as force-leading moved `.mixin2()` output
+           * ahead of an intervening nested rule in the Less property-accessor corpus.
+           */
+          const bodyForceLeading = forceLeading || def.params.length !== 0;
 
-        /*
-         * [adjacent-merge] each mixin expansion is a DISTINCT parent expansion: give
-         * its body a FRESH composed-array identity (same values → byte-identical
-         * composition) so nested rulesets from two separate calls of the same body do
-         * NOT reopen-merge (`.class .inner {} .class .inner {}` stay two blocks —
-         * `mixins-important`), while two nested siblings within ONE expansion still
-         * share it and merge.
-         */
-        const bodyComposed = composed === null ? null : composed.slice();
-        const executeBody = () => {
-          const bodyTrivia = def.rules.length === 0 ? undefined : bodyTriviaReplay(def, e);
-          const pluginVersion = e.fnScopeVersion ?? 0;
-          return mapMaybe(
-            prepareBodyPlugins(def.rules, callFrame, e),
-            () => {
-              if (!bindingsTrackedAtDispatch && (e.fnScopeVersion ?? 0) !== pluginVersion && bindings !== null) {
-                capturePreparedBodyPluginBindings(def, call, bindings, frame, homeFrame, e);
-              }
-              return mapMaybe(
-                walkBody(
+          /*
+           * [adjacent-merge] each mixin expansion is a DISTINCT parent expansion: give
+           * its body a FRESH composed-array identity (same values → byte-identical
+           * composition) so nested rulesets from two separate calls of the same body do
+           * NOT reopen-merge (`.class .inner {} .class .inner {}` stay two blocks —
+           * `mixins-important`), while two nested siblings within ONE expansion still
+           * share it and merge.
+           */
+          const bodyComposed = composed === null ? null : composed.slice();
+          let bodyTrivia: BodyTriviaReplay | undefined;
+          const executeBody = () => {
+            bodyTrivia = def.rules.length === 0 ? undefined : bodyTriviaReplay(def, e);
+            const pluginVersion = e.fnScopeVersion ?? 0;
+            return mapMaybe(
+              prepareBodyPlugins(def.rules, callFrame, e),
+              () => {
+                if (!bindingsTrackedAtDispatch && (e.fnScopeVersion ?? 0) !== pluginVersion && bindings !== null) {
+                  capturePreparedBodyPluginBindings(def, call, bindings, frame, homeFrame, e);
+                }
+                if (sharedLeaves !== undefined) {
+                  const placement = def.ruleMixin === true && source !== null
+                    ? { source, callFrame } satisfies NestedRuleMixinPlacement
+                    : null;
+                  return emitNestedBody(
+                    def.rules,
+                    callFrame,
+                    e,
+                    undefined,
+                    bodyImp,
+                    source,
+                    placement,
+                    sharedLeaves,
+                    applyExpansion,
+                    undefined,
+                    bodyTrivia
+                  );
+                }
+                return walkBody(
                   def.rules,
                   bodyComposed,
                   ancestor,
@@ -11396,16 +11431,28 @@ function expandCall(
                   applyExpansion,
                   false,
                   bodyTrivia
-                ),
-                () => {
-                  queueBodyTriviaTail(bodyTrivia, group, partition, e);
-                }
-              );
-            }
-          );
-        };
-        const emitted = withSourceOwner(e, callFrame.sourceOwner, executeBody);
-        return mapMaybe(emitted, () => {
+                );
+              }
+            );
+          };
+          const emitted = withSourceOwner(e, callFrame.sourceOwner, executeBody);
+          if (isThenable(emitted)) {
+            return emitted.then(() => {
+              if (sharedLeaves === undefined) {
+                queueBodyTriviaTail(bodyTrivia, group, partition, e);
+              }
+              leakBodyVars(frame, def.rules, callFrame, e);
+              publishOrderedMixins(frame, frameOrderedMixins(callFrame, e), callFrame);
+              if (def.ruleMixin !== true) {
+                publishExplicitRulesets(frame, def.rules, callFrame);
+              }
+              return run(index + 1);
+            });
+          }
+          if (sharedLeaves === undefined) {
+            queueBodyTriviaTail(bodyTrivia, group, partition, e);
+          }
+
           /*
            * [scope-leak] after expansion the mixin's own `@x:` declarations unlock into
            * the caller scope (visible to later siblings), matching less@4.
@@ -11427,26 +11474,25 @@ function expandCall(
           if (def.ruleMixin !== true) {
             publishExplicitRulesets(frame, def.rules, callFrame);
           }
-          return expandSelected(index + 1);
-        });
+        }
       };
       try {
-        const expanded = expandSelected(0);
+        const expanded = run(0);
         if (isThenable(expanded)) {
           return expanded.then(
             () => {
-              finish();
+              e.mixinDepth--;
             },
             (error) => {
-              finish();
+              e.mixinDepth--;
               throw error;
             }
           );
         }
-        finish();
-        return;
+        e.mixinDepth--;
+        return expanded;
       } catch (error) {
-        finish();
+        e.mixinDepth--;
         throw error;
       }
     });
@@ -11496,7 +11542,9 @@ function expandApply(
   e: Emit,
   imp = false,
   forceLeading = false,
-  propertyScope: Frame = frame
+  propertyScope: Frame = frame,
+  source: NestedHeaderSource | null = null,
+  sharedLeaves?: NestedLeafBuffer
 ): MaybePromise<void> {
   const selected: Array<{ rule: Ruleset; home: Frame }> = [];
 
@@ -11539,10 +11587,32 @@ function expandApply(
       };
       const emitted = withSourceOwner(e, applyFrame.sourceOwner, () => mapMaybe(
         prepareBodyPlugins(rule.rules, applyFrame, e),
-        () => walkBody(
-          rule.rules, composed, ancestor, applyFrame, group, flush, partition, e,
-          imp, forceLeading, propertyScope, true
-        )
+        () => sharedLeaves === undefined
+          ? walkBody(
+              rule.rules,
+              composed,
+              ancestor,
+              applyFrame,
+              group,
+              flush,
+              partition,
+              e,
+              imp,
+              forceLeading,
+              propertyScope,
+              true
+            )
+          : emitNestedBody(
+              rule.rules,
+              applyFrame,
+              e,
+              undefined,
+              imp,
+              source,
+              null,
+              sharedLeaves,
+              true
+            )
       ));
       if (isThenable(emitted)) {
         return emitted.then(() => run(index + 1));
@@ -11711,7 +11781,7 @@ function finishDefaultMixinValues(
 }
 
 /** Closure-bearing args capture their literal home frame in render-local state. */
-function captureArgDefFrames(bindings: Map<string, Binding> | null, callerFrame: Frame, callFrame: Frame, e: EvalCtx): void {
+function captureArgDefFrames(bindings: Map<string, Binding> | null, callerFrame: Frame, callFrame: Frame): void {
   if (!bindings) {
     return;
   }
@@ -11721,8 +11791,6 @@ function captureArgDefFrames(bindings: Map<string, Binding> | null, callerFrame:
     }
     if (isValueBlock(v)) {
       bindDetached(callFrame, v, callerFrame, callerFrame.sourceOwner ?? null);
-    } else if (v.type === 'MixinCall') {
-      (e.mixinCallHomes ??= new WeakMap()).set(v, callerFrame);
     }
   }
 }
@@ -11991,9 +12059,12 @@ function expandReferenceCall(
   flush: () => MaybePromise<void>,
   partition: Partition | null, // [partition] nested-ruleset sink (see walkBody)
   e: Emit,
+  imp = false,
   forceLeading = false, // [partition] inherited leading-hoist context
   propertyScope: Frame = frame,
-  applyExpansion = false
+  applyExpansion = false,
+  source: NestedHeaderSource | null = null,
+  sharedLeaves?: NestedLeafBuffer
 ): MaybePromise<void> {
   /*
    * `@alias: .something(foo); @alias();` — a variable bound to a MIXIN CALL is
@@ -12008,13 +12079,29 @@ function expandReferenceCall(
   const resolved = resolveReferenceResult(call, frame, e);
   if (!resolved) {
     if (call.base.type === 'Lookup' && call.base.kind === 'var') {
-      unresolvedSymbol(call.base, `@${call.base.name}`, e);
+      unresolvedSymbol(call, `@${call.base.name}`, e);
     }
     return;
   }
   if (isMixinCallValue(resolved.value)) {
-    const home = e.mixinCallHomes?.get(resolved.value) ?? resolved.frame ?? frame;
-    return expandCall(resolved.value, composed, ancestor, home, group, flush, partition, e, false, forceLeading, undefined, propertyScope, applyExpansion);
+    const home = resolved.frame ?? frame;
+    return expandCall(
+      resolved.value,
+      composed,
+      ancestor,
+      home,
+      group,
+      flush,
+      partition,
+      e,
+      imp,
+      forceLeading,
+      undefined,
+      propertyScope,
+      applyExpansion,
+      source,
+      sharedLeaves
+    );
   }
   if (step.args.length !== 0) {
     throw new Error('Reference call arguments require a callable mixin target.');
@@ -12041,7 +12128,32 @@ function expandReferenceCall(
   const drBody = valueBlockBody(r.dr);
   const executeBody = () => mapMaybe(
     prepareBodyPlugins(drBody, r.callFrame, e),
-    () => walkBody(drBody, composed, ancestor, r.callFrame, group, flush, partition, e, false, forceLeading, propertyScope, applyExpansion)
+    () => sharedLeaves === undefined
+      ? walkBody(
+          drBody,
+          composed,
+          ancestor,
+          r.callFrame,
+          group,
+          flush,
+          partition,
+          e,
+          imp,
+          forceLeading,
+          propertyScope,
+          applyExpansion
+        )
+      : emitNestedBody(
+          drBody,
+          r.callFrame,
+          e,
+          undefined,
+          imp,
+          source,
+          null,
+          sharedLeaves,
+          applyExpansion
+        )
   );
   return withSourceOwner(e, r.callFrame.sourceOwner, executeBody);
 }
@@ -16041,7 +16153,23 @@ function emitNestedBody(
         }
         case 'MixinCall':
           {
-            const emitted = expandNestedCall(node, frame, e, imp, source, inlineLeaves, applyExpansion);
+            const emitted = expandCall(
+              node,
+              null,
+              null,
+              frame,
+              inlineLeaves.leaves,
+              inlineLeaves.flush,
+              null,
+              e,
+              imp,
+              false,
+              undefined,
+              inlineLeaves.propertyScope,
+              applyExpansion,
+              source,
+              inlineLeaves
+            );
             if (isThenable(emitted)) {
               return emitted.then(() => run(index + 1));
             }
@@ -16049,7 +16177,21 @@ function emitNestedBody(
           break;
         case 'Apply':
           {
-            const emitted = expandNestedApply(node, frame, e, imp, source, inlineLeaves);
+            const emitted = expandApply(
+              node,
+              null,
+              null,
+              frame,
+              inlineLeaves.leaves,
+              inlineLeaves.flush,
+              null,
+              e,
+              imp,
+              false,
+              inlineLeaves.propertyScope,
+              source,
+              inlineLeaves
+            );
             if (isThenable(emitted)) {
               return emitted.then(() => run(index + 1));
             }
@@ -16057,7 +16199,22 @@ function emitNestedBody(
           break;
         case 'Reference':
           {
-            const emitted = expandNestedReferenceCall(node, frame, e, imp, source, inlineLeaves, applyExpansion);
+            const emitted = expandReferenceCall(
+              node,
+              null,
+              null,
+              frame,
+              inlineLeaves.leaves,
+              inlineLeaves.flush,
+              null,
+              e,
+              imp,
+              false,
+              inlineLeaves.propertyScope,
+              applyExpansion,
+              source,
+              inlineLeaves
+            );
             if (isThenable(emitted)) {
               return emitted.then(() => run(index + 1));
             }
@@ -16378,14 +16535,14 @@ function emitTransparentShells(
       const callFrame: Frame = {
         parent: shell.home,
         mixins: collectMixins(shell.def.rules),
-        declIndex: collectDeclIndex(shell.def.rules, shell.bindings), cells: cellsForParams(shell.bindings), reassign: null,
+        declIndex: collectDeclIndex(shell.def.rules, shell.bindings), cells: cellsForParams(shell.bindings, undefined, frame), reassign: null,
         statements: shell.def.rules,
         sourceOwner: sourceOwnerForBody(shell.def.rules, frame, e),
         mixinUrlBindings: undefined,
         mixinValueBindings: undefined
       };
       takeMixinValueBindings(shell.boundSourceKeys, e, callFrame);
-      captureArgDefFrames(shell.bindings, frame, callFrame, e);
+      captureArgDefFrames(shell.bindings, frame, callFrame);
       const source: NestedHeaderSource = { parent: parentSource, selector: shell.rule.selector, frame };
       const header = nestedSourceStrings(source, e);
       const markChunks = e.chunks.length;
@@ -16706,264 +16863,6 @@ function emitHoisted(rule: Ruleset, frame: Frame, e: Emit): MaybePromise<void> {
   }
   e.hoistMode = prev;
   return emitted;
-}
-
-/**
- * Expand a mixin call in nested mode: select the matching overloaded
- * definitions, then SPLICE each shared body inline at the current level — the
- * body's declarations join the call-site block and its nested rules nest under
- * the call site (own selectors). No clone, no per-placement node build.
- */
-function expandNestedCall(
-  call: MixinCall,
-  frame: Frame,
-  e: Emit,
-  imp = false,
-  source: NestedHeaderSource | null = null,
-  sharedLeaves?: NestedLeafBuffer,
-  applyExpansion = false
-): MaybePromise<void> {
-  /*
-   * Candidate resolution mirrors the flat-path {@link expandCall}: a bare `.m()`
-   * walks the scope chain accumulating same-name overloads (explicit `MixinDefinition`s
-   * AND paren-less rulesets callable as zero-arg mixins), a namespaced/compound
-   * call descends by element value; both record each candidate's DEFINITION frame
-   * in `homes` so the body + guards resolve free variables in the mixin's CLOSURE
-   * scope, not the call site (`mixins-closure`).
-   */
-  const namespaced = call.path.length > 0;
-  const homes = new Map<MixinDefinition, Frame>();
-
-  /*
-   * Candidate lookup builds each frame index as it reaches it, which can await
-   * when a rule's mixin key is interpolated from an awaitable value.
-   */
-  return mapMaybe(namespaced
-    ? findPathCandidates(frame, call, e, homes)
-    : lookupCandidates(frame, call.name, e, homes), (rawCandidates) => {
-  /*
-   * [parent-exclusion] a paren-less ruleset-mixin does not re-enter its own body
-   * while it is on the active expansion stack (see `expandCall`).
-   */
-    const candidates = rawCandidates.some(d => d.ruleMixin === true)
-      ? rawCandidates.filter(d => d.ruleMixin !== true || !parentExcludes(frame, d.rules))
-      : rawCandidates;
-    if (rawCandidates.length === 0) {
-      unresolvedMixinCall(call, e);
-    }
-    if (candidates.length === 0) {
-      return;
-    }
-    const bindingsTrackedAtDispatch = e.pluginHost?.invokeRawFunction !== undefined
-      && (e.scopedFunctionNames?.size ?? 0) > 0;
-    const runDispatch = (): MaybePromise<void> => mapMaybe(dispatch(candidates, call, frame, e, homes, true), (selected) => {
-      if (sharedLeaves !== undefined) {
-        queueCommentOnlySelectedBodies(selected, e, sharedLeaves.leaves);
-      }
-      if (selected.length === 0) {
-        return;
-      }
-      const bodyImp = imp || call.important; // [important] propagate call-level `!important`
-      if (e.mixinDepth >= MAX_MIXIN_DEPTH) {
-        throw new RangeError('maximum mixin recursion depth exceeded');
-      }
-      e.mixinDepth++;
-      const run = (start: number): MaybePromise<void> => {
-        for (let index = start; index < selected.length; index++) {
-          const { def, bindings, boundSourceKeys } = selected[index]!;
-
-          /*
-           * [closure] free variables resolve in the mixin's DEFINITION scope first, with
-           * the call-site scope as a fallback (a namespaced call is confined to the
-           * namespace, so it takes no caller fallback) — the same layering `expandCall`
-           * builds for the flat path.
-          */
-          const homeFrame = homes.get(def) ?? frame;
-          const callFrame: Frame = {
-            parent: homeFrame,
-            mixins: collectMixins(def.rules),
-            declIndex: collectDeclIndex(def.rules, bindings), cells: cellsForParams(bindings), reassign: null,
-            statements: def.rules,
-            sourceOwner: sourceOwnerForBody(def.rules, frame, e),
-            mixinUrlBindings: undefined,
-            mixinValueBindings: undefined,
-            ...(namespaced || homeFrame === frame ? {} : { fallback: frame })
-          };
-          takeMixinValueBindings(boundSourceKeys, e, callFrame);
-          captureArgDefFrames(bindings, frame, callFrame, e);
-          const placement = def.ruleMixin === true && source !== null
-            ? { source, callFrame } satisfies NestedRuleMixinPlacement
-            : null;
-          const executeBody = () => {
-            /* The selected-body prequeue is the sole owner of comment-only bodies. */
-            const bodyTrivia = def.rules.length === 0 ? undefined : bodyTriviaReplay(def, e);
-            const pluginVersion = e.fnScopeVersion ?? 0;
-            return mapMaybe(
-              prepareBodyPlugins(def.rules, callFrame, e),
-              () => {
-                if (!bindingsTrackedAtDispatch && (e.fnScopeVersion ?? 0) !== pluginVersion && bindings !== null) {
-                  capturePreparedBodyPluginBindings(def, call, bindings, frame, homeFrame, e);
-                }
-                return emitNestedBody(
-                  def.rules,
-                  callFrame,
-                  e,
-                  undefined,
-                  bodyImp,
-                  source,
-                  placement,
-                  sharedLeaves,
-                  applyExpansion,
-                  undefined,
-                  bodyTrivia
-                );
-              }
-            );
-          };
-          const emitted = withSourceOwner(e, callFrame.sourceOwner, executeBody);
-          if (isThenable(emitted)) {
-            return emitted.then(() => {
-              leakBodyVars(frame, def.rules, callFrame, e);
-              publishOrderedMixins(frame, frameOrderedMixins(callFrame, e), callFrame);
-              if (def.ruleMixin !== true) {
-                publishExplicitRulesets(frame, def.rules, callFrame);
-              }
-              return run(index + 1);
-            });
-          }
-
-          /*
-           * [scope-leak] the mixin's own `@x:` declarations and nested rulesets unlock
-           * into the caller scope for later siblings (less@4 splices evaluated rules as
-           * siblings of the call), matching the flat path.
-           */
-          leakBodyVars(frame, def.rules, callFrame, e);
-          publishOrderedMixins(frame, frameOrderedMixins(callFrame, e), callFrame);
-          if (def.ruleMixin !== true) {
-            publishExplicitRulesets(frame, def.rules, callFrame);
-          }
-        }
-      };
-      const emitted = run(0);
-      if (isThenable(emitted)) {
-        return emitted.then(
-          () => {
-            e.mixinDepth--;
-          },
-          (error) => {
-            e.mixinDepth--;
-            throw error;
-          }
-        );
-      }
-      e.mixinDepth--;
-      return emitted;
-    });
-    return runDispatch();
-  });
-}
-
-/** Nested-mode counterpart of {@link expandApply}. It keeps `$apply`'s
- * ruleset-only selection and explicit duplicate-preservation fact while sharing
- * the same canonical bodies and lexical frames as every other core expansion. */
-function expandNestedApply(
-  node: Apply,
-  frame: Frame,
-  e: Emit,
-  imp = false,
-  source: NestedHeaderSource | null = null,
-  sharedLeaves?: NestedLeafBuffer
-): MaybePromise<void> {
-  const selected: Array<{ rule: Ruleset; home: Frame }> = [];
-
-  /*
-   * [guards] Selecting which ruleset-mixin bodies apply may need an awaitable
-   * guard value, so candidates are gathered first and their guards folded in
-   * order — the fold stays fully synchronous until a guard actually awaits.
-   */
-  const candidates: Array<{ rule: Ruleset; home: Frame }> = [];
-  for (const selector of node.selectors) {
-    const key = selectorTermCanonical(selector);
-    for (let scope: Frame | null = frame; scope; scope = scope.parent) {
-      const matches = frameRulesets(scope)?.get(key);
-      if (!matches) {
-        continue;
-      }
-      for (const rule of matches) {
-        if (!parentExcludes(frame, rule.rules)) {
-          candidates.push({ rule, home: scope });
-        }
-      }
-    }
-  }
-  const gather = serialForEach(candidates, ({ rule, home }) =>
-    mapMaybe(ruleGuardPasses(rule, home, e), (passes) => {
-      if (passes) {
-        selected.push({ rule, home });
-      }
-    }));
-  const run = (start: number): MaybePromise<void> => {
-    for (let index = start; index < selected.length; index++) {
-      const { rule, home } = selected[index]!;
-      const applyFrame: Frame = {
-        parent: home,
-        mixins: collectMixins(rule.rules),
-        declIndex: collectDeclIndex(rule.rules), cells: null, reassign: null,
-        statements: rule.rules,
-        sourceOwner: sourceOwnerForBody(rule.rules, frame, e),
-        ...(home === frame ? {} : { fallback: frame })
-      };
-      const emitted = withSourceOwner(e, applyFrame.sourceOwner, () => mapMaybe(
-        prepareBodyPlugins(rule.rules, applyFrame, e),
-        () => emitNestedBody(rule.rules, applyFrame, e, undefined, imp, source, null, sharedLeaves, true)
-      ));
-      if (isThenable(emitted)) {
-        return emitted.then(() => run(index + 1));
-      }
-    }
-  };
-  return mapMaybe(gather, () => run(0));
-}
-
-/** Expand a detached-ruleset call in nested mode. */
-function expandNestedReferenceCall(
-  call: Reference,
-  frame: Frame,
-  e: Emit,
-  imp = false,
-  source: NestedHeaderSource | null = null,
-  sharedLeaves?: NestedLeafBuffer,
-  applyExpansion = false
-): MaybePromise<void> {
-  /*
-   * A variable bound to a MIXIN CALL (`@alias: .something(foo); @alias();`) is
-   * dispatched as that call, not spliced as a detached ruleset.
-   */
-  const step = call.steps.at(-1);
-  if (step?.type !== 'Call') {
-    return;
-  }
-  const resolved = resolveReferenceResult(call, frame, e);
-  if (!resolved) {
-    return;
-  }
-  if (isMixinCallValue(resolved.value)) {
-    return expandNestedCall(resolved.value, frame, e, imp, source, sharedLeaves, applyExpansion);
-  }
-  if (step.args.length !== 0) {
-    throw new Error('Reference call arguments require a callable mixin target.');
-  }
-  const dr = resolveValueBlock(resolved.value, resolved.frame, e);
-  if (!dr) {
-    return;
-  }
-  const r = referenceCallFrame(dr, frame, resolved.frame, resolved.sourceOwner);
-  const drBody = valueBlockBody(r.dr);
-  const executeBody = () => mapMaybe(
-    prepareBodyPlugins(drBody, r.callFrame, e),
-    () => emitNestedBody(drBody, r.callFrame, e, undefined, imp, source, null, sharedLeaves, applyExpansion)
-  );
-  return withSourceOwner(e, r.callFrame.sourceOwner, executeBody);
 }
 
 /** Expand an `each()` loop in nested mode: splice the callback body once per item

--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -4839,9 +4839,14 @@ function resolveReferenceResult(
           /* Exclude the alias currently being followed so `@call: @call`
            * reaches its prior parameter binding instead of selecting itself. */
           const alias = value;
-          e.excluded.add(alias);
+          const aliasWasExcluded = e.excluded.has(alias);
+          if (!aliasWasExcluded) {
+            e.excluded.add(alias);
+          }
           const aliased = resolveVarRef(valueFrame, name, scope, e);
-          e.excluded.delete(alias);
+          if (!aliasWasExcluded) {
+            e.excluded.delete(alias);
+          }
           if (!aliased) {
             break;
           }

--- a/packages/jess/test/less/structural-error-public-semantics.test.ts
+++ b/packages/jess/test/less/structural-error-public-semantics.test.ts
@@ -32,6 +32,52 @@ const cases = [
 ] as const;
 
 describe('Less structural errors through the public AST route', () => {
+  it('keeps a callable-body lookup diagnostic at the same source position in both projections', async () => {
+    const source = '.mixin() {\n  color: @missing;\n}\n.entry { .mixin(); }';
+    const positions: Array<{ code: string; line: number; column: number }> = [];
+
+    for (const collapseNesting of [false, true]) {
+      const result = await new Compiler({ output: { collapseNesting } }).renderToResult({
+        source,
+        filePath: 'entry.less',
+        extension: '.less'
+      }, {
+        breakOnError: false,
+        suppressWarnings: true
+      });
+      const error = result.errors[0]!;
+      positions.push({ code: error.code, line: error.line!, column: error.column! });
+    }
+
+    expect(positions).toEqual([
+      { code: 'resolve/name-not-found', line: 2, column: 10 },
+      { code: 'resolve/name-not-found', line: 2, column: 10 }
+    ]);
+  });
+
+  it('reports a missing detached reference at the same source position in both projections', async () => {
+    const source = '.entry { @missing(); }';
+    const positions: Array<{ code: string; line: number; column: number }> = [];
+
+    for (const collapseNesting of [false, true]) {
+      const result = await new Compiler({ output: { collapseNesting } }).renderToResult({
+        source,
+        filePath: 'entry.less',
+        extension: '.less'
+      }, {
+        breakOnError: false,
+        suppressWarnings: true
+      });
+      const error = result.errors[0]!;
+      positions.push({ code: error.code, line: error.line!, column: error.column! });
+    }
+
+    expect(positions).toEqual([
+      { code: 'resolve/name-not-found', line: 1, column: 10 },
+      { code: 'resolve/name-not-found', line: 1, column: 10 }
+    ]);
+  });
+
   it.each(cases)('reports %s', async (_label, source, code) => {
     const compiler = new Compiler({ output: { collapseNesting: true } });
     await expect(compiler.renderString(source, {


### PR DESCRIPTION
## Why

DESIGN-DECISIONS V19 makes evaluation and lookup functions of the source stylesheet; `collapseNesting` is output policy only. The serializer still had separate collapsed and nested implementations for mixin calls, `$apply`, and detached-reference calls. That duplication had already produced projection-specific failures in importance, closure lookup, diagnostic positions, and trivia replay.

This is evaluator-fold Slice 2 from the HANDOFF plan. It moves callable selection and evaluation to one path while retaining the two existing streaming body writers for the later control-flow and container slices.

## What changed

- Deleted `expandNestedCall`, `expandNestedApply`, and `expandNestedReferenceCall`.
- Made `expandCall`, `expandApply`, and `expandReferenceCall` the single owners of callable lookup/selection, activation frames, body plugin preparation, recursion accounting, scope leakage/publication, detached-body execution, importance, diagnostics, and trivia ownership.
- Kept projection as the final direct branch into `walkBody` or `emitNestedBody`; there is no writer callback, adapter, carrier, retained evaluated tree, or extra helper rung.
- Removed the render-global `WeakMap<MixinCall, Frame>`. A call-valued parameter now carries its caller frame on the existing activation-local `BindingCell.valueFrame` slot, using the existing four-field cell shape.
- Made self-reading call aliases (`@call: @call`) fall through the existing binding-cell chain to the prior parameter without recursive alias selection.

## Red-to-green and sensitivity evidence

- Reuses the exact same canonical call nodes in two caller frames and requires red then green output in both projections, including a same-name self-copy.
- Pins inherited `!important` for detached references in both projections.
- Pins missing callable diagnostics to line/column 2:10 and missing detached references to 1:10 in both projections.
- Pins `$apply` body placement and callable scope publication in both projections.
- Removing the shared `leakBodyVars` calls makes the named publication test fail and changes exactly `tests-config/namespacing/namespacing-4.less` and `tests-unit/scope/scope.less` in the forced-collapse manifest.
- Substituting the base lookup node for the authored call changes the pinned diagnostic column from 10 to 1.
- Doubling body-write instrumentation fails at 16 versus the expected 8.

For N=4 self-copying call-valued activations, both modes measured 8 evaluator entries, 8 body writes, 4 owner-aware cells, and 20 bounded previous-cell steps. At 2N=8 the counts were 16/16/8/40. Temporary instrumentation was removed before commit.

## Deterministic architecture counts

| Counter | Before | After |
|---|---:|---:|
| `serialize.ts` lines | 17,089 | 16,993 |
| named functions | 421 | 418 |
| arrow sites | 605 | 583 |
| `Map` constructions | 58 | 57 |
| `Set` constructions | 34 | 34 |
| `WeakMap` constructions | 6 | 5 |
| `Frame` construction sites | 30 | 28 |
| leaf groups | 9 | 9 |
| `mapMaybe` sites | 135 | 126 |
| `.then` sites | 108 | 106 |
| evaluator-side `e.collapse` reads | 2 | 2 |

The remaining two output-setting reads belong to later V19 slices; this slice adds none.

## Verification

- `pnpm run build:release`: green.
- `npx vitest run packages/core`: 200 files passed; 3,194 tests passed, 8 skipped, 2 todo.
- `pnpm --dir packages/jess run test:ratchet`: 1,423 tests; 0 current failures; gating and flaky named-baseline sets match exactly (both empty).
- normal all-less corpus: 112/112.
- forced `collapseNesting:true`: 111 before/after named records; zero additions/removals/changes; manifest SHA-256 `f45fdeeb52bf1e000dba6c9fdd953de3ceabff1ed6ebccb522c890072ed9dc6c` in both runs.
- selected both-mode Jess tests: 73/73, including `property-accessor-nested` 4/4.
- dependents: plugin-less 14/14; fns 718/718; plugin-scss 2/2.
- `pnpm run check:guardrails`, `pnpm run verify:aggressive-cutting-review`, touched-file lint, and `git diff --check`: green.
- `verify:shape-stability`: inherited target-branch red on the stale AST corpus type inventory and `SpacedValue` allowlist; its monomorphic-node assertion and all five CST assertions pass. This diff changes no parser or node shape.

## Performance

Canonical `measure:less:hotpath`, Node 24.11.1, same machine/session, Less test-data 5.0.0-alpha.3 at `3af87fc`; output bytes and SHA-256 are identical before/after for every fixture.

Collapsed (`true`):

| Fixture | Before | After | Delta | Same-commit null |
|---|---:|---:|---:|---:|
| functions | 5.414 ms (12.8%, usable) | 5.006 ms (14.2%, usable) | -7.5% | 4.874 ms |
| import-reference | 8.380 ms (10.2%, usable) | 7.582 ms (10.2%, usable) | -9.5% | 7.712 ms |
| mixins-guards | 5.950 ms (26.2%, noisy) | 5.295 ms (18.8%, unstable) | -11.0% | 5.447 ms |
| extend-chaining | 1.821 ms (21.3%, unstable) | 1.410 ms (15.8%, unstable) | -22.5% | 1.577 ms |
| media | 1.867 ms (16.6%, unstable) | 1.637 ms (12.9%, usable) | -12.3% | 1.599 ms |

Nested (`false`):

| Fixture | Before | After | Delta | Same-commit null |
|---|---:|---:|---:|---:|
| functions | 5.443 ms (19.0%, unstable) | 5.891 ms (16.7%, unstable) | +8.2% | 4.917 ms |
| import-reference | 9.043 ms (13.7%, usable) | 9.184 ms (10.8%, usable) | +1.6% | 7.327 ms |
| mixins-guards | 5.128 ms (19.1%, unstable) | 5.583 ms (22.7%, unstable) | +8.9% | 5.617 ms |
| extend-chaining | 1.426 ms (21.3%, unstable) | 1.395 ms (35.8%, noisy) | -2.2% | 1.391 ms |
| media | 1.551 ms (12.1%, usable) | 1.686 ms (27.7%, noisy) | +8.7% | 1.703 ms |

The harness cannot attribute a regression: the larger positive deltas occur in unstable/noisy samples, the sole usable positive delta is only 1.6%, and the same-commit null run itself moves materially. No speed or neutrality claim is made.

## Review findings acted on

- Removed the initial polymorphic writer callback/adapters and call the existing writer directly.
- Replaced recursive synchronous selected-body continuation with an iterative loop; recursion remains only after an actual suspension.
- Constructed owner-aware binding cells in the existing field order instead of adding a property after allocation.
- Replaced the render-global call-home WeakMap with activation-local context state.
- Bounded the rare self-copy lookup to the existing same-name cell chain and added N/2N operation evidence.
- Moved trivia acquisition inside the selected definition's source-owner scope.
- Propagated inherited importance and used the authored call node for diagnostics.
- Removed a temporary closure/helper around alias exclusion.
- Preserved an enclosing alias-exclusion owner by deleting the alias only when the local resolution scope added it (CodeRabbit).

Final semantics review passes all eight invariants and incident obligations S1-S7 under V19/G28. Final performance-architecture review passes invariants 1-11 and incidents R1-R8 with no code-level blocker.

## Remaining fold

Slices 3-5 still move control flow, containers/imports/hoisting, then delete the second statement dispatcher and take evaluator-side nesting-setting reads to zero.
