### PR TITLE
refactor(core): share container evaluation

### DIFF
--- a/docs/architecture/core/HANDOFF.md
+++ b/docs/architecture/core/HANDOFF.md
@@ -4028,78 +4028,84 @@ involved.
 
 ## Aggressive Cutting Self-Prosecution
 
-- Latest pass: 2026-09-03 V19 slice 3 shared control-flow evaluation. This folds
-  `$for` iterable evaluation and per-iteration activation into one implementation,
-  keeps the already-shared `$if` and `$while` evaluators explicit, and retains the two
+- Latest pass: 2026-09-03 V19 slice 4 shared container evaluation. This folds ruleset
+  guards and extend-hoist placement, at-rule prelude evaluation and activation, and
+  stylesheet-import execution into shared evaluator entries while retaining the two
   existing streaming writers; it makes no speed claim.
-- Architecture surface: `serialize.ts` `$for` iterable resolution, planned extend
-  placement, loop bindings and frames, detached binding, plugin preparation, async
-  continuation, `$if` arm selection, and the collapsed/nested writer boundary. Parser
-  grammar, canonical node schemas, public package APIs, selector composition, at-rule
-  bubbling, trivia ownership, and output-option ownership are unchanged.
-- Separation/duplication: `expandNestedFor` is deleted. `expandFor` now evaluates each
-  source loop once and directly enters `walkBody` or `emitNestedBody` according to the
-  already-live nested leaf context. `selectIfBody` is projection-neutral, and
-  `runWhile` remains the sole condition/iteration driver. The projection branch
-  allocates no carrier and adds no callback/helper rung.
+- Architecture surface: `serialize.ts` rulesets, block at-rules, stylesheet imports,
+  ordinary rule activation frames, nested extend hoist queues, and the collapsed/nested
+  writer boundary. Parser grammar, canonical node schemas, public package APIs, selector
+  composition policy, at-rule bubbling policy, and output-option ownership are unchanged.
+- Separation/duplication: `expandRule`, `expandAtRuleBlock`, and `expandStyleImport` are
+  the projection-neutral entries. `emitNestedRule`, `emitNestedRuleGuarded`, and
+  `emitNestedAtRuleBlock` are deleted. `activateRuleFrame` creates/reuses the ordinary
+  ruleset activation for either writer. The nested writer receives evaluator-issued
+  hoists; the collapsed writer retains composition, bubbling, and partition policy.
 - Cumulative node weight: canonical AST/CST nodes, `Frame`, `EvalCtx`, `Emit`, and
-  `BindingCell` gain zero fields. Static `Map`, `Set`, and `WeakMap` constructions stay
-  at 57, 34, and 5. Per-iteration state remains on the existing short-lived loop
-  `Frame`; no render-global identity table or parallel context model is introduced.
-- New traversal: no AST/source traversal. The shared evaluator performs the existing
-  typed iterable resolution once, then uses one synchronous `for` loop and recurses
-  only when an existing async body suspends. Temporary instrumentation measured N=4
-  as 1 evaluator entry, 4 loop frames, 4 body evaluations, and 4 writer entries; N=8
-  measured 1/8/8/8 in both projections. Deliberately doubling the writer count failed
-  at 8 and 16, proving the counter gate detects duplicate work.
+  `BindingCell` gain zero fields. Static `Map` constructions fall 57 to 56; `Set` and
+  `WeakMap` stay 34 and 5. All transient facts remain on existing short-lived `Frame`,
+  `Emit`, placement-map, and writer-local queue lifetimes. No new context field, identity
+  table, or parallel state model is introduced; `WeakMap` remains a last resort, unused
+  by this fold.
+- New traversal: no AST/source traversal. The shared entries evaluate the existing rule
+  guard, at-rule prelude, and import request once. Nested hoisting performs one existing
+  projection-plan lookup and one queue append per crossing source rule. N=8 and N=16
+  produce exactly 8 and 16 `astExtend.emit.nestedHoistPlacements`; a disposable
+  per-subject rescan raised N=8 to 72 and failed the operation-budget test.
 - New node/materialization: zero AST/CST nodes, retained evaluated trees, projection
-  wrappers, new group arrays, Maps, Sets, WeakMaps, or per-entry event objects. The
-  shared path constructs the same one loop `Frame` per source item that each old path
-  constructed; `Frame` construction sites fall 28 to 27.
-- Render path: both projections still stream into `Emit.chunks`. Iterable resolution,
-  placement cursor consumption, bindings, lexical value ownership, plugins, and
-  continuation order are shared. Only the final direct body-writer call differs.
-  Collapsed output retains `walkBody`; nested output retains `emitNestedBody` with the
-  caller's existing leaf buffer and source owner.
-- Helper/API surface: private serializer machinery only. Named functions fall 418 to
-  417, raw arrow sites 583 to 579, `mapMaybe` sites 126 to 124, and `.then` sites 106
-  to 105. The shared loop body has no added writer callback, adapter, closure, carrier,
-  or helper-call rung.
-- Metadata mutations: only existing activation-local frame and render-context state
-  mutates: the planned placement cursor advances, then bindings and selected-declaration
-  indexes populate the same short-lived frames as before. Canonical source nodes,
-  public results, parser trivia, and shared source facts remain immutable.
-- Review-flagged diff tokens: [conditional writer] one direct branch selects the
-  existing writer after evaluation state is ready; [positional parameters] two existing
-  nested-writer inputs were added to avoid allocating a carrier object or retained
-  event list; [loop/traversal] the synchronous item path remains iterative and N/2N
-  counters are exactly linear; [side map] no new Map, Set, WeakMap, Frame field, or
-  context table; [routine error control] no Error allocation or exception was added for
-  ordinary control flow; [source scan/reparse] none.
-- Behavior evidence: focused control-flow tests pass 35/35. Exact both-mode output pins
-  per-iteration value/index bindings followed by a later declaration, and an actually
-  suspended `each()` iterable resolves in source order in both projections. Existing
-  nested-loop, guard, plugin-scope, selected-arm, property-merge, detached-binding, and
-  G28 trivia tests remain green. The source ratchet fails if `expandNestedFor` returns
-  or the helper/collection ceilings grow.
+  wrappers, new group arrays, Maps, Sets, WeakMaps, or per-entry event objects. Sharing
+  ordinary ruleset and at-rule activation removes two statically authored `Frame`
+  construction sites, 27 to 25.
+- Render path: both projections still stream into `Emit.chunks`. Ruleset guard and hoist
+  decisions precede a direct writer call; at-rule prelude resolution and body-frame
+  creation precede a direct resolved-writer call. `walkBody` retains collapsed layout;
+  `emitNestedBody` retains authored nesting and consumes the same evaluated entries.
+- Helper/API surface: private serializer machinery only. Named functions fall 417 to
+  415, raw arrow sites 579 to 577, `mapMaybe` sites 126 to 124, and `.then` stays 105.
+  The entries use fixed positional arguments to avoid a projection carrier, callback
+  adapter, closure, retained event list, or helper-call ladder.
+- Metadata mutations: only existing render-local placement state mutates. Rule activation
+  is recorded in `Frame.rulePlacements`; import facts retain their existing frame/source-
+  order publication; nested hoists append to the already-owned writer queue. Canonical
+  source nodes, public results, parser trivia, and shared source facts remain immutable.
+- Review-flagged diff tokens: [conditional writer] direct branches select the existing
+  writers after shared evaluation; [positional parameters] existing writer facts are
+  passed without a carrier allocation; [loop/traversal] no new production loop and the
+  N/2N hoist counter is exactly linear; [side map] one `Map` construction is removed and
+  no Map, Set, WeakMap, Frame field, or context table is added; [routine error control]
+  no Error allocation or exception is added for ordinary control flow; [source scan/
+  reparse] none.
+- Behavior evidence: focused container/import/extend tests pass 88/88. Exact both-mode
+  diagnostic positions include an at-rule prelude lookup at line 1, column 20; a
+  disposable one-byte source-span shift changed both projections to column 21 and failed
+  the test. Existing selector composition, ampersand, bubbling, import barrier/order,
+  reference visibility, block-comment, property-accessor, async continuation, and plugin
+  scope tests remain green. The source ratchet rejects restored nested container/import
+  evaluators, an extra collapse read, or helper/collection growth.
 - Build evidence: dependency-ordered `pnpm run build:release` passes. Root core passes
-  200 files / 3,197 tests / 8 skipped / 2 todo. Jess ratchet passes 1,424 tests with
-  zero current, gating-baseline, or flaky-baseline failures; normal all-less passes
-  112/112. The forced-collapse before/after manifests contain the same 111 named
-  records and identical SHA-256
-  `f45fdeeb52bf1e000dba6c9fdd953de3ceabff1ed6ebccb522c890072ed9dc6c`.
-  Selected both-mode/property suites pass 73/73. Dependents pass plugin-less 14/14,
+  200 files / 3,199 tests / 8 skipped / 2 todo. Jess ratchet passes 1,425 tests with zero
+  current, gating-baseline, or flaky-baseline failures; normal all-less passes 112/112.
+  The forced-collapse before/after manifests contain the same 111 named records and are
+  byte-identical with SHA-256
+  `ab837140229078bfd56a5ab47fe07dc26ceaf34b339f68e8adab67da4ec5499c`.
+  Selected both-mode/property suites pass 74/74. Dependents pass plugin-less 14/14,
   fns 718/718, and plugin-scss 2/2. Guardrails, aggressive-cutting, touched-added-line
-  lint, and diff-check pass. Shape stability is identical before/after: its monomorphic
-  AST and all CST assertions pass while the stale AST corpus inventory and
-  `SpacedValue` allowlist checks remain red. Static counts are `serialize.ts` 16,993 to
-  16,988 lines, Map 57 to 57, Set 34 to 34, WeakMap 5 to 5, Frame sites 28 to 27,
-  Leaf groups 9 to 9, and evaluator-side `e.collapse` reads 2 to 2. Standard hot-path
-  timings are noisy beyond the apparent deltas and support no speed or neutrality claim.
-- Boundary evidence: no public type/export changes. Exact-head semantics review
-  approves invariants 1-8 and the incident catalogue under SETTLED V19 and G28, finding
-  no output-policy or transient-state blocker. Exact-head performance review must
-  approve invariants 1-11 against this current self-prosecution before landing.
+  lint, and diff-check pass. Shape stability retains the inherited result: its
+  monomorphic AST and all CST assertions pass while the stale AST corpus inventory and
+  `SpacedValue` allowlist checks remain red. Static counts are `serialize.ts` 16,988 to
+  16,958 lines, Map 57 to 56, Set 34 to 34, WeakMap 5 to 5, Frame sites 27 to 25,
+  Leaf groups 9 to 9, and evaluator-side `e.collapse` reads 2 to 1.
+- Performance evidence: the standard 100-iteration x 5-round harness used Node 24.11.1
+  and Less test data 5.0.0-alpha.3 at `3af87fc0` in one session. A paired late pass has
+  collapsed before/after medians (ms) functions 4.112/4.344, import-reference
+  6.886/6.660, mixins-guards 4.456/4.277, extend-chaining 1.114/1.065, media 1.551/1.418;
+  nested 3.661/3.739, 6.456/6.279, 4.452/4.238, 1.033/1.015, 1.506/1.449. The sole
+  positive collapsed delta is contradicted by an +8.3% same-commit null movement;
+  nested's +2.1% functions delta is unstable. The harness cannot attribute a regression,
+  so no speed or neutrality claim is made.
+- Boundary evidence: no public type/export changes. Exact-head semantics and performance
+  reviews must approve their complete invariant sets against this current self-
+  prosecution before landing.
 - Hot-path cost contracts:
 ```json
 [
@@ -4122,10 +4128,10 @@ involved.
       "recursive-ValueGroup-final-unit-validation",
       "async-declaration-dedup-output-order"
     ],
-    "why": "SETTLED V19 makes evaluation and lookup functions of the source stylesheet, independent of nesting output. Slice 3 deletes the nested-only loop evaluator and sends one shared iterable/activation result directly to the existing collapsed or nested writer.",
-    "dangerTokensJustification": "The final projection choice is one allocation-free branch on the already-live nested leaf context and calls the existing writer directly. The per-item path retains a synchronous for loop and recurses only after a real suspension. No Map, Set, WeakMap, Frame field, context table, writer callback, carrier, or retained event list is added. N/2N instrumentation measured one evaluator entry and exactly N loop frames, body evaluations, and writer entries in both modes.",
-    "behaviorEvidence": "Focused control-flow suites pass. Exact both-mode output pins source-order loop bindings and a suspended iterable; the source ratchet rejects a restored nested loop evaluator or helper/collection growth. N/2N and doubled-writer probes are sensitive.",
-    "buildEvidence": "Dependency-order build passes. Core passes 3197 tests; Jess ratchet passes 1424 with empty current/gating/flaky failure sets; all-less passes 112/112; the 111-record forced-collapse manifests are identical; selected both-mode Jess tests pass 73/73; dependents pass 14/14, 718/718, and 2/2. Guardrails, aggressive-cutting, touched-added-line lint, and diff-check pass. Shape stability is identical before/after: monomorphic AST and all CST assertions pass while the stale AST inventory/SpacedValue allowlist checks remain red. Static counts: lines 16993 to 16988, named functions 418 to 417, arrows 583 to 579, Map 57 unchanged, Set 34 unchanged, WeakMap 5 unchanged, Frame sites 28 to 27. Same-session hot-path timings are reported separately and carry no speed claim.",
+    "why": "SETTLED V19 makes evaluation and lookup functions of the source stylesheet, independent of nesting output. Slice 4 deletes nested-only rule guard and at-rule prelude evaluators and gives both projections shared ruleset, at-rule, import, activation-frame, and hoist-placement entries.",
+    "dangerTokensJustification": "Projection choice is an allocation-free branch after shared evaluation and calls the existing writer directly. Existing Frame, Emit, placement-map, and writer-local queue lifetimes own all transient facts. No Map, Set, WeakMap, Frame field, context table, writer callback, carrier, retained event list, source scan, or reparse is added. N/2N instrumentation measured exactly one nested hoist placement per crossing source rule.",
+    "behaviorEvidence": "Focused container/import/extend suites pass 88/88. Both-mode at-rule diagnostic positions and nested-hoist N/2N budgets have demonstrated negative controls; the source ratchet rejects restored nested evaluators, an extra collapse read, or helper/collection growth.",
+    "buildEvidence": "Dependency-order build passes. Core passes 3199 tests; Jess ratchet passes 1425 with empty current/gating/flaky failure sets; all-less passes 112/112; the 111-record forced-collapse manifests are byte-identical; selected both-mode Jess tests pass 74/74; dependents pass 14/14, 718/718, and 2/2. Guardrails, aggressive-cutting, touched-added-line lint, and diff-check pass. Shape stability retains the inherited result: monomorphic AST and all CST assertions pass while the stale AST inventory/SpacedValue allowlist checks remain red. Static counts: lines 16988 to 16958, named functions 417 to 415, arrows 579 to 577, Map 57 to 56, Set 34 unchanged, WeakMap 5 unchanged, Frame sites 27 to 25, and collapse reads 2 to 1. Same-session hot-path timings are reported separately and carry no speed claim.",
     "baseline": {
       "fixture": "benchmark.less",
       "phase": "render",
@@ -4136,10 +4142,10 @@ involved.
   }
 ]
 ```
-- Verdict: accepted as the smallest V19 control-flow evaluator fold after the current
-  self-prosecution, both-mode behavior pins, deterministic linear counter probe, and
-  same-session timing evidence. Timing is explicitly inconclusive and supports no
-  speed or neutrality claim.
+- Verdict: accepted as the smallest V19 container evaluator fold after the current
+  self-prosecution, both-mode behavior pins, deterministic linear hoist counter, and
+  same-session timing evidence. Timing is explicitly inconclusive and supports no speed
+  or neutrality claim.
 
 - Previous pass: 2026-09-03 V19 slice 1 shared lookup and leaf bookkeeping. This
   is the first evaluator-fold slice and a correctness correction with no speed claim.

--- a/packages/core/src/ast/__tests__/extend-op-budget.test.ts
+++ b/packages/core/src/ast/__tests__/extend-op-budget.test.ts
@@ -112,6 +112,34 @@ const contribComposesFor = (n: number): number => {
   return counters['astExtend.buildContribs.instructionsComposed'] ?? 0;
 };
 
+/** N repeated cross-`&` children, each requiring one nested-writer hoist placement. */
+const nestedHoistDoc = (n: number): ReturnType<CoreAst['stylesheet']> => {
+  const children = [];
+  for (let index = 0; index < n; index++) {
+    children.push(ast.rule(ast.complexSelector([
+      { term: ast.compoundSelectorOf([ast.simpleSelector(`.prefix-${index}`)]) },
+      { combinator: ' ', term: ast.compoundSelectorOf([ast.simpleSelector('&')]) },
+      { combinator: ' ', term: ast.compoundSelectorOf([ast.simpleSelector('.leaf')]) }
+    ]), [ast.decl(`value-${index}`, ast.keyword('yes'))]));
+  }
+  return ast.stylesheet([
+    ast.rule('.parent', children),
+    ast.rule('.alias', [], [{
+      target: ast.selist(ast.complexSelector([
+        { term: ast.compoundSelectorOf([ast.simpleSelector('.parent')]) },
+        { combinator: ' ', term: ast.compoundSelectorOf([ast.simpleSelector('.leaf')]) }
+      ])),
+      partial: true
+    }])
+  ]);
+};
+
+const nestedHoistPlacementsFor = (n: number): number => {
+  resetCounters();
+  serialize(nestedHoistDoc(n), { collapseNesting: false });
+  return counters['astExtend.emit.nestedHoistPlacements'] ?? 0;
+};
+
 const DISCOVER = process.env.EXTEND_BUDGET_DISCOVER === 'true';
 
 describe('extend operation-counter budgets', () => {
@@ -221,5 +249,14 @@ describe('extend operation-counter budgets', () => {
       + `the document has ONE instruction, so both must equal it. A larger count means `
       + `buildContribs went back to recomposing per subject instead of using the render memo.`
     ).toBe(base);
+  });
+
+  it('issues one nested hoist placement per crossing source rule', () => {
+    const base = nestedHoistPlacementsFor(8);
+    const doubled = nestedHoistPlacementsFor(16);
+
+    expect(base).toBe(8);
+    expect(doubled).toBe(16);
+    expect(doubled).toBeLessThanOrEqual(base * 2);
   });
 });

--- a/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
+++ b/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
@@ -41,7 +41,7 @@ describe('V19 one-evaluator projection ratchet', () => {
   });
 
   it('does not grow the serializer helper or collection-construction surface', () => {
-    expect(occurrences(/^function |^async function /gmu)).toBe(417);
+    expect(occurrences(/^function |^async function /gmu)).toBe(416);
     expect(occurrences(/new Map/gu)).toBe(57);
     expect(occurrences(/new Set/gu)).toBe(34);
     expect(occurrences(/new WeakMap/gu)).toBe(5);
@@ -74,5 +74,18 @@ describe('V19 one-evaluator projection ratchet', () => {
     expect(occurrences(/selectIfBodyForRender\(/gu)).toBe(0);
     expect(occurrences(/selectIfBody\(/gu)).toBe(6);
     expect(occurrences(/runWhile\(/gu)).toBe(6);
+  });
+
+  it('keeps one evaluator for containers, at-rules, imports, and hoist placement', () => {
+    expect(occurrences(/function expandRule\(/gu)).toBe(1);
+    expect(occurrences(/function flatten\(/gu)).toBe(0);
+    expect(occurrences(/function emitNestedRule\(/gu)).toBe(0);
+    expect(occurrences(/function activateRuleFrame\(/gu)).toBe(1);
+    expect(occurrences(/function expandAtRuleBlock\(/gu)).toBe(1);
+    expect(occurrences(/function emitAtRuleBlock\(/gu)).toBe(0);
+    expect(occurrences(/function emitNestedAtRuleBlock\(/gu)).toBe(0);
+    expect(occurrences(/function expandStyleImport\(/gu)).toBe(1);
+    expect(occurrences(/function emitStyleImport\(/gu)).toBe(0);
+    expect(occurrences(/astExtend\.emit\.nestedHoistPlacements/gu)).toBe(1);
   });
 });

--- a/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
+++ b/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
@@ -20,12 +20,11 @@ describe('V19 one-evaluator projection ratchet', () => {
   });
 
   it('names every output-setting read that can select evaluation behavior', () => {
-    expect(occurrences(/\be\.collapse\b/gu)).toBe(2);
+    expect(occurrences(/\be\.collapse\b/gu)).toBe(1);
     expect(SOURCE).toContain(
       'if (!e.collapse && e.referenceImportDepth === 0 && !hasDynamicImportTarget)'
     );
-    expect(SOURCE).toContain('function emitNestedRuleGuarded(');
-    expect(SOURCE).toContain('  if (!e.collapse) {');
+    expect(SOURCE).not.toContain('function emitNestedRuleGuarded(');
   });
 
   it('keeps one leaf shape and no pending-comment side table', () => {
@@ -41,8 +40,8 @@ describe('V19 one-evaluator projection ratchet', () => {
   });
 
   it('does not grow the serializer helper or collection-construction surface', () => {
-    expect(occurrences(/^function |^async function /gmu)).toBe(416);
-    expect(occurrences(/new Map/gu)).toBe(57);
+    expect(occurrences(/^function |^async function /gmu)).toBe(415);
+    expect(occurrences(/new Map/gu)).toBe(56);
     expect(occurrences(/new Set/gu)).toBe(34);
     expect(occurrences(/new WeakMap/gu)).toBe(5);
     expect(occurrences(/const group: Leaf\[\] = \[\]/gu)).toBe(9);

--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -9567,7 +9567,7 @@ function emitDocumentStatements(
         continue;
       }
       flushBatch();
-      const emit = () => emitStyleImport(child, frame, e, importDocument);
+      const emit = () => expandStyleImport(child, frame, e, importDocument);
       if (pending) {
         pending = pending.then(() => Promise.resolve(emit()));
       } else {
@@ -9650,7 +9650,7 @@ function emitDocumentStatements(
           || referenceRuleIsVisible(child, frame, e)
           || extendProjection(frame, e)?.visibleReferenceRuleAncestors?.has(child) === true) {
           emitBeforeDocumentStatement(child);
-          const emitted = flatten(child, null, null, frame, e);
+          const emitted = expandRule(child, null, null, frame, e);
           markAfterDocumentStatement(child);
           return emitted;
         }
@@ -9658,7 +9658,7 @@ function emitDocumentStatements(
       case 'MixinDefinition':
         if (imported) {
           /*
-           * `emitStyleImport` already published this definition in the import's
+           * `expandStyleImport` already published this definition in the import's
            * source-order callable stream. Keep its existing ordinary-call
            * publication, but do not record the same source statement twice.
            */
@@ -9748,7 +9748,7 @@ function emitDocumentStatements(
         if (e.referenceImportDepth === 0
           || extendProjection(frame, e)?.visibleReferenceAtRules?.has(child) === true) {
           emitBeforeDocumentStatement(child);
-          const emitted = emitAtRuleBlock(child, frame, e);
+          const emitted = expandAtRuleBlock(child, frame, e);
           markAfterDocumentStatement(child);
           return emitted;
         }
@@ -9769,7 +9769,7 @@ function emitDocumentStatements(
       case 'StyleImport':
         emitBeforeDocumentStatement(child);
         {
-          const emitted = emitStyleImport(child, frame, e, importDocument);
+          const emitted = expandStyleImport(child, frame, e, importDocument);
           markAfterDocumentStatement(child);
           return emitted;
         }
@@ -10137,19 +10137,55 @@ function referenceRuleIsVisible(rule: Ruleset, frame: Frame, e: Emit): boolean {
   return false;
 }
 
-function flatten(
+/**
+ * Evaluate shared ruleset gates and placement, then call the selected writer.
+ * The optional nested arguments are existing writer state; their presence chooses
+ * the projection without consulting the output setting during evaluation.
+ */
+function expandRule(
   rule: Ruleset,
   parent: string[] | null,
   ancestor: string | null,
   frame: Frame,
   e: Emit,
   imp = false,
-  expandBubbledSelectorList = false
+  expandBubbledSelectorList = false,
+  nestedSource?: NestedHeaderSource | null,
+  nestedPlacement: NestedRuleMixinPlacement | null = null,
+  nestedHoist?: HoistEntry[]
 ): MaybePromise<void> {
+  if (nestedSource !== undefined && nestedHoist !== undefined) {
+    const nestedPlan = extendProjection(frame, e)?.nestedPlan.get(rule);
+    if (nestedPlan?.flatten) {
+      recordAstExtendProfile?.('astExtend.emit.nestedHoistPlacements');
+      nestedHoist.push({ rule, frame, bubble: nestedPlan.hoistBubble ?? 1 });
+      return;
+    }
+  }
+
   // [guards] a guarded ruleset emits its block only when the guard is true.
   return mapMaybe(ruleGuardPasses(rule, frame, e), (passes) => {
     if (!passes) {
       return;
+    }
+    if (nestedSource !== undefined) {
+      return mapMaybe(transparentShells(rule, frame, e), shells => (shells !== null
+        ? emitTransparentShells(
+            shells,
+            { parent: nestedSource, selector: rule.selector, frame },
+            frame,
+            e,
+            imp
+          )
+        : writeNestedRule(
+            rule,
+            frame,
+            e,
+            imp,
+            nestedSource,
+            nestedPlacement,
+            nestedHoist
+          )));
     }
     const rawComposed =
       parent === null ? rootStrings(rule.selector, frame, e) : compose(parent, rule.selector, frame, e);
@@ -10233,6 +10269,22 @@ function flattenResolved(
     ));
 }
 
+/** Establish one ordinary visible ruleset activation for either writer. */
+function activateRuleFrame(rule: Ruleset, frame: Frame, e: EvalCtx): Frame {
+  const priorPlacement = frame.rulePlacements?.get(rule);
+  const childFrame: Frame = priorPlacement?.parent === frame
+    ? priorPlacement
+    : {
+        parent: frame,
+        mixins: collectMixins(rule.rules),
+        declIndex: collectDeclIndex(rule.rules), cells: null, reassign: null,
+        statements: rule.rules,
+        sourceOwner: sourceOwnerForBody(rule.rules, frame, e)
+      };
+  (frame.rulePlacements ??= new Map()).set(rule, childFrame);
+  return childFrame;
+}
+
 function flattenWithHeader(
   rule: Ruleset,
   parent: string[] | null,
@@ -10272,22 +10324,7 @@ function flattenWithHeader(
   if (header === null && !referenceAncestor) {
     return;
   }
-  const priorPlacement = frame.rulePlacements?.get(rule);
-  const childFrame: Frame = priorPlacement?.parent === frame
-    ? priorPlacement
-    : {
-        parent: frame,
-        mixins: collectMixins(rule.rules),
-        declIndex: collectDeclIndex(rule.rules), cells: null, reassign: null,
-        statements: rule.rules,
-        sourceOwner: sourceOwnerForBody(rule.rules, frame, e)
-      };
-
-  /*
-   * Keep the exact render placement: imports within this Ruleset publish into its
-   * child frame and become visible to a later namespace descent through Ruleset.
-   */
-  (frame.rulePlacements ??= new Map()).set(rule, childFrame);
+  const childFrame = activateRuleFrame(rule, frame, e);
 
   /*
    * [import:reference] A hidden parent selector can be structurally necessary
@@ -10732,19 +10769,19 @@ function walkBody(
           queueLeadingGroup(group, partition, e);
           flushPending(partition);
           partition.encounteredContainer = true;
-          partition.trailing.push(() => flatten(rule, rComposed, rAncestor, rFrame, e, imp, expandBubbledSelectorList));
+          partition.trailing.push(() => expandRule(rule, rComposed, rAncestor, rFrame, e, imp, expandBubbledSelectorList));
         } else {
           const flushed = flush();
           if (isThenable(flushed)) {
             return flushed.then(() => mapMaybe(
-              flatten(rule, rComposed, rAncestor, rFrame, e, imp, expandBubbledSelectorList),
+              expandRule(rule, rComposed, rAncestor, rFrame, e, imp, expandBubbledSelectorList),
               () => walkBody(
                 statements.slice(index + 1), composed, ancestor, frame, group, flush,
                 partition, e, imp, forceLeading, propertyScope, applyExpansion, expandBubbledSelectorList
               )
             ));
           }
-          const emitted = flatten(rule, rComposed, rAncestor, rFrame, e, imp, expandBubbledSelectorList);
+          const emitted = expandRule(rule, rComposed, rAncestor, rFrame, e, imp, expandBubbledSelectorList);
           if (isThenable(emitted)) {
             return emitted.then(() => walkBody(
               statements.slice(index + 1), composed, ancestor, frame, group, flush,
@@ -10857,14 +10894,14 @@ function walkBody(
         const targetDepth = e.atRuleBodyDepth;
         const emitAt = (): MaybePromise<void> => {
           if (targetDepth === e.depth) {
-            return emitAtRuleBlock(atNode, atFrame, e, atComposed);
+            return expandAtRuleBlock(atNode, atFrame, e, atComposed);
           }
           const savedDepth = e.depth;
           e.depth = targetDepth;
           const restore = (): void => {
             e.depth = savedDepth;
           };
-          const r = emitAtRuleBlock(atNode, atFrame, e, atComposed);
+          const r = expandAtRuleBlock(atNode, atFrame, e, atComposed);
           if (isThenable(r)) {
             return r.then(restore, (err) => {
               restore();
@@ -10960,14 +10997,14 @@ function walkBody(
           const flushed = flush();
           if (isThenable(flushed)) {
             return flushed.then(() => mapMaybe(
-              emitStyleImport(node, frame, e, e.importDocument),
+              expandStyleImport(node, frame, e, e.importDocument),
               () => walkBody(
                 statements.slice(index + 1), composed, ancestor, frame, group,
                 flush, partition, e, imp, forceLeading, propertyScope
               )
             ));
           }
-          const imported = emitStyleImport(node, frame, e, e.importDocument);
+          const imported = expandStyleImport(node, frame, e, e.importDocument);
           if (isThenable(imported)) {
             return imported.then(() => walkBody(
               statements.slice(index + 1), composed, ancestor, frame, group,
@@ -10980,7 +11017,7 @@ function walkBody(
           const flushed = flush();
           if (isThenable(flushed)) {
             return flushed.then(() => mapMaybe(
-              emitStyleImport(node, frame, e, e.importDocument),
+              expandStyleImport(node, frame, e, e.importDocument),
               () => walkBody(
                 statements.slice(index + 1), composed, ancestor, frame, group,
                 flush, partition, e, imp, forceLeading, propertyScope
@@ -10993,7 +11030,7 @@ function walkBody(
            * asynchronous Context IO. Keep this body cursor alive so a deferred
            * callable's document scope survives the raw-byte read.
            */
-          const imported = emitStyleImport(node, frame, e, e.importDocument);
+          const imported = expandStyleImport(node, frame, e, e.importDocument);
           if (isThenable(imported)) {
             return imported.then(() => walkBody(
               statements.slice(index + 1), composed, ancestor, frame, group,
@@ -11089,11 +11126,11 @@ function walkReferenceAncestorBody(
       let emitted: MaybePromise<void>;
       switch (node.type) {
         case 'Ruleset':
-          emitted = flatten(node, composed, ancestor, frame, e, imp, expandBubbledSelectorList);
+          emitted = expandRule(node, composed, ancestor, frame, e, imp, expandBubbledSelectorList);
           break;
         case 'AtRuleBlock':
           emitted = extendProjection(frame, e)?.visibleReferenceAtRules?.has(node) === true
-            ? emitAtRuleBlock(node, frame, e, composed)
+            ? expandAtRuleBlock(node, frame, e, composed)
             : undefined;
           break;
         case 'For':
@@ -13981,7 +14018,7 @@ function emitLeafOwned(leaf: Leaf, e: Emit, atRoot = false): void {
      * block level deeper than the containing declarations.
      */
     e.depth++;
-    settledEmission(emitAtRuleBlock(node, frame, e), node, e);
+    settledEmission(expandAtRuleBlock(node, frame, e), node, e);
     e.depth--;
   } else if (node.type === 'AtRuleStatement') {
     e.depth++;
@@ -13989,7 +14026,7 @@ function emitLeafOwned(leaf: Leaf, e: Emit, atRoot = false): void {
     e.depth--;
   } else if (node.type === 'StyleImport') {
     e.depth++;
-    settledEmission(emitStyleImport(node, frame, e, e.importDocument), node, e);
+    settledEmission(expandStyleImport(node, frame, e, e.importDocument), node, e);
     e.depth--;
   } else if (node.type === 'UnknownAtRuleBlock') {
     e.depth++;
@@ -14336,7 +14373,7 @@ function emitAtRuleStatementRaw(
  * Core deliberately knows neither paths nor parser plugins; a declined request
  * remains a CSS import statement.
  */
-function emitStyleImport(
+function expandStyleImport(
   node: StyleImport,
   frame: Frame,
   e: Emit,
@@ -15191,18 +15228,34 @@ function atRulePreludeBytes(node: AtRuleBlock, frame: Frame, e: Emit): MaybeProm
   return evalBytes(node.prelude, frame, e);
 }
 
-function emitAtRuleBlock(node: AtRuleBlock, frame: Frame, e: Emit, ctx: string[] | null = null): MaybePromise<void> {
+function expandAtRuleBlock(
+  node: AtRuleBlock,
+  frame: Frame,
+  e: Emit,
+  ctx: string[] | null = null,
+  nestedSource?: NestedHeaderSource | null
+): MaybePromise<void> {
   /*
    * The prelude resolves BEFORE any byte is written, so the rewind marks below
    * still bracket exactly this at-rule's output.
    */
-  return mapMaybe(atRulePreludeBytes(node, frame, e), prelude =>
-    emitAtRuleBlockResolved(node, frame, e, ctx, prelude));
+  return mapMaybe(atRulePreludeBytes(node, frame, e), (prelude) => {
+    const bodyFrame: Frame = {
+      parent: frame,
+      mixins: collectMixins(node.rules),
+      declIndex: collectDeclIndex(node.rules), cells: null, reassign: null,
+      statements: node.rules
+    };
+    return nestedSource === undefined
+      ? writeCollapsedAtRuleBlock(node, frame, bodyFrame, e, ctx, prelude)
+      : writeNestedAtRuleBlock(node, frame, bodyFrame, e, nestedSource, prelude);
+  });
 }
 
-function emitAtRuleBlockResolved(
+function writeCollapsedAtRuleBlock(
   node: AtRuleBlock,
   frame: Frame,
+  bodyFrame: Frame,
   e: Emit,
   ctx: string[] | null,
   prelude: string
@@ -15223,12 +15276,6 @@ function emitAtRuleBlockResolved(
   }
   put(e, ' {\n');
   const afterHeader = e.chunks.length;
-  const bodyFrame: Frame = {
-    parent: frame,
-    mixins: collectMixins(node.rules),
-    declIndex: collectDeclIndex(node.rules), cells: null, reassign: null,
-    statements: node.rules
-  };
   const emitted = prepareBodyPlugins(node.rules, bodyFrame, e);
   const finish = (): MaybePromise<void> => {
     if (e.chunks.length === afterHeader) {
@@ -15378,11 +15425,11 @@ function emitAtRuleBody(
         }
         return undefined;
       case 'Ruleset':
-        return nested(node, () => flatten(node, null, null, frame, e));
+        return nested(node, () => expandRule(node, null, null, frame, e));
       case 'AtRuleBlock':
         return e.referenceImportDepth === 0
           || extendProjection(frame, e)?.visibleReferenceAtRules?.has(node) === true
-          ? nested(node, () => emitAtRuleBlock(node, frame, e))
+          ? nested(node, () => expandAtRuleBlock(node, frame, e))
           : undefined;
       case 'AtRuleStatement':
         return e.referenceImportDepth === 0
@@ -15391,7 +15438,7 @@ function emitAtRuleBody(
       case 'Plugin':
         return undefined;
       case 'StyleImport':
-        return nested(node, () => emitStyleImport(node, frame, e, e.importDocument));
+        return nested(node, () => expandStyleImport(node, frame, e, e.importDocument));
       case 'ModuleImport':
         return e.referenceImportDepth === 0
           ? nested(node, () => {
@@ -15567,7 +15614,7 @@ function emitBubbleBody(
           if (deferStaticChildren) {
             deferredChildren!.push(() => {
               e.depth++;
-              const emitted = flatten(node, ctx, ctxAncestor, frame, e, false, ctx !== null);
+              const emitted = expandRule(node, ctx, ctxAncestor, frame, e, false, ctx !== null);
               if (isThenable(emitted)) {
                 return emitted.then(() => {
                   e.depth--;
@@ -15583,7 +15630,7 @@ function emitBubbleBody(
             if (isThenable(flushed)) {
               return flushed.then(() => {
                 e.depth++;
-                const emitted = flatten(node, ctx, ctxAncestor, frame, e, false, ctx !== null);
+                const emitted = expandRule(node, ctx, ctxAncestor, frame, e, false, ctx !== null);
                 if (isThenable(emitted)) {
                   return emitted.then(
                     () => {
@@ -15602,7 +15649,7 @@ function emitBubbleBody(
             }
             e.depth++;
             {
-              const emitted = flatten(node, ctx, ctxAncestor, frame, e, false, ctx !== null);
+              const emitted = expandRule(node, ctx, ctxAncestor, frame, e, false, ctx !== null);
               if (isThenable(emitted)) {
                 return emitted.then(
                   () => {
@@ -15627,7 +15674,7 @@ function emitBubbleBody(
           if (deferStaticChildren) {
             deferredChildren!.push(() => {
               e.depth++;
-              const nested = emitAtRuleBlock(node, frame, e, ctx);
+              const nested = expandAtRuleBlock(node, frame, e, ctx);
               if (isThenable(nested)) {
                 return nested.then(() => {
                   e.depth--;
@@ -15643,7 +15690,7 @@ function emitBubbleBody(
             if (isThenable(flushed)) {
               return flushed.then(() => {
                 e.depth++;
-                const nested = emitAtRuleBlock(node, frame, e, ctx);
+                const nested = expandAtRuleBlock(node, frame, e, ctx);
                 if (isThenable(nested)) {
                   return nested.then(
                     () => {
@@ -15661,7 +15708,7 @@ function emitBubbleBody(
               });
             }
             e.depth++;
-            const nested = emitAtRuleBlock(node, frame, e, ctx); // directly-nested at-rule inherits ctx
+            const nested = expandAtRuleBlock(node, frame, e, ctx); // directly-nested at-rule inherits ctx
             if (isThenable(nested)) {
               return nested.then(
                 () => {
@@ -15707,7 +15754,7 @@ function emitBubbleBody(
           if (isThenable(flushed)) {
             return flushed.then(() => {
               e.depth++;
-              const imported = emitStyleImport(
+              const imported = expandStyleImport(
                 node,
                 frame,
                 e,
@@ -15744,7 +15791,7 @@ function emitBubbleBody(
             });
           }
           e.depth++;
-          const imported = emitStyleImport(
+          const imported = expandStyleImport(
             node,
             frame,
             e,
@@ -16152,24 +16199,26 @@ function emitNestedBody(
           emitBeforeRootStatement(node);
 
           /*
-           * [extend] a rule whose extend match crosses the `&` FLATTENS: defer it to
-           * the enclosing rule's hoist queue. `hoistBubble` (default 1) is how many
-           * enclosing blocks it must rise out of — the per-boundary hoist distance.
-           */
-          if (hoist && extendProjection(frame, e)?.nestedPlan.get(node)?.flatten) {
-            const plan = extendProjection(frame, e)!.nestedPlan.get(node)!;
-            hoist.push({ rule: node, frame, bubble: plan.hoistBubble ?? 1 });
-            markAfterRootStatement(node);
-            break;
-          }
-
-          /*
            * Only a selected synthesized ruleset mixin gets a placement fact.  It
            * is consumed by the first `&`-bearing nested header; ordinary authored
            * nesting has no fact and stays literal in collapse:false mode.
            */
-          const appliesPlacement = placement !== null && selectorListHasAmpersand(node.selector);
-          const emitted = emitNestedRule(node, frame, e, imp, source, appliesPlacement ? placement : null, hoist);
+          const appliesPlacement = placement !== null
+            && !(hoist !== undefined
+              && extendProjection(frame, e)?.nestedPlan.get(node)?.flatten === true)
+            && selectorListHasAmpersand(node.selector);
+          const emitted = expandRule(
+            node,
+            null,
+            null,
+            frame,
+            e,
+            imp,
+            false,
+            source,
+            appliesPlacement ? placement : null,
+            hoist
+          );
           if (isThenable(emitted)) {
             return emitted.then(() => {
               if (appliesPlacement) {
@@ -16300,7 +16349,7 @@ function emitNestedBody(
           flushBuf();
           emitBeforeRootStatement(node);
           {
-            const emitted = emitNestedAtRuleBlock(node, frame, e, source);
+            const emitted = expandAtRuleBlock(node, frame, e, null, source);
             if (isThenable(emitted)) {
               return emitted.then(() => {
                 markAfterRootStatement(node);
@@ -16320,7 +16369,7 @@ function emitNestedBody(
           flushBuf();
           emitBeforeRootStatement(node);
           {
-            const imported = emitStyleImport(
+            const imported = expandStyleImport(
               node,
               frame,
               e,
@@ -16636,54 +16685,7 @@ function emitTransparentShells(
   return run(0);
 }
 
-function emitNestedRule(
-  rule: Ruleset,
-  frame: Frame,
-  e: Emit,
-  imp = false,
-  source: NestedHeaderSource | null = null,
-  placement: NestedRuleMixinPlacement | null = null,
-
-  /*
-   * [extend] the ENCLOSING block's hoist queue: a crossing child that must rise more
-   * than one level (`bubble > 1`) is re-pushed here (decremented) instead of emitted
-   * at this rule's level, so it keeps bubbling up the ancestor chain until it lands.
-   */
-  outerHoist?: HoistEntry[]
-): MaybePromise<void> {
-  /*
-   * [guards] a guarded ruleset emits its block only when the guard is true (the
-   * flattened path applies the same gate in `flatten`).
-   */
-  return mapMaybe(ruleGuardPasses(rule, frame, e), passes => passes
-    ? emitNestedRuleGuarded(rule, frame, e, imp, source, placement, outerHoist)
-    : undefined);
-}
-
-function emitNestedRuleGuarded(
-  rule: Ruleset,
-  frame: Frame,
-  e: Emit,
-  imp: boolean,
-  source: NestedHeaderSource | null,
-  placement: NestedRuleMixinPlacement | null,
-  outerHoist?: HoistEntry[]
-): MaybePromise<void> {
-  if (!e.collapse) {
-    return mapMaybe(transparentShells(rule, frame, e), shells => (shells !== null
-      ? emitTransparentShells(
-          shells,
-          { parent: source, selector: rule.selector, frame },
-          frame,
-          e,
-          imp
-        )
-      : emitNestedRuleAuthored(rule, frame, e, imp, source, placement, outerHoist)));
-  }
-  return emitNestedRuleAuthored(rule, frame, e, imp, source, placement, outerHoist);
-}
-
-function emitNestedRuleAuthored(
+function writeNestedRule(
   rule: Ruleset,
   frame: Frame,
   e: Emit,
@@ -16785,20 +16787,8 @@ function emitNestedRuleAuthored(
       put(e, ' {\n');
     }
     const afterHeader = e.chunks.length;
-    const childFrame: Frame = {
-      parent: frame,
-      mixins: collectMixins(rule.rules),
-      declIndex: collectDeclIndex(rule.rules), cells: null, reassign: null,
-      statements: rule.rules
-    };
+    const childFrame = activateRuleFrame(rule, frame, e);
     const childSource: NestedHeaderSource = { parent: source, selector: rule.selector, frame };
-
-    /*
-     * Nested output owns the same lexical placement facts as flattened output:
-     * a later namespace call must enter this exact child frame to see imports that
-     * executed inside the Ruleset.
-     */
-    (frame.rulePlacements ??= new Map()).set(rule, childFrame);
 
     /*
      * [extend] children that flatten (extend crossed the `&`) bubble out to this
@@ -16877,7 +16867,7 @@ function emitNestedRuleAuthored(
             continue;
           }
           const emitted = extendProjection(h.frame, e)?.nestedPlan.get(h.rule)?.hoistNested
-            ? emitNestedRule(h.rule, h.frame, e, imp)
+            ? expandRule(h.rule, null, null, h.frame, e, imp, false, null)
             : emitHoisted(h.rule, h.frame, e);
           if (isThenable(emitted)) {
             return emitted.then(() => runHoist(hoistIndex + 1));
@@ -16898,7 +16888,7 @@ function emitNestedRuleAuthored(
 function emitHoisted(rule: Ruleset, frame: Frame, e: Emit): MaybePromise<void> {
   const prev = e.hoistMode;
   e.hoistMode = true;
-  const emitted = flatten(rule, null, null, frame, e);
+  const emitted = expandRule(rule, null, null, frame, e);
   if (isThenable(emitted)) {
     return emitted.then(
       () => {
@@ -16914,25 +16904,11 @@ function emitHoisted(rule: Ruleset, frame: Frame, e: Emit): MaybePromise<void> {
   return emitted;
 }
 
-/**
- * A block at-rule in nested mode: `@name prelude { …body }`. The header sits at
- * the current level; the body is a fresh nesting context one level deeper whose
- * nested rulesets STAY nested (they are not flattened). An at-rule whose body
- * renders empty is dropped entirely.
- */
-function emitNestedAtRuleBlock(
+/** Write one prelude-resolved at-rule through the authored-nesting projection. */
+function writeNestedAtRuleBlock(
   node: AtRuleBlock,
   frame: Frame,
-  e: Emit,
-  source: NestedHeaderSource | null = null
-): MaybePromise<void> {
-  return mapMaybe(atRulePreludeBytes(node, frame, e), prelude =>
-    emitNestedAtRuleBlockResolved(node, frame, e, source, prelude));
-}
-
-function emitNestedAtRuleBlockResolved(
-  node: AtRuleBlock,
-  frame: Frame,
+  bodyFrame: Frame,
   e: Emit,
   source: NestedHeaderSource | null,
   prelude: string
@@ -16952,12 +16928,6 @@ function emitNestedAtRuleBlockResolved(
   }
   put(e, ' {\n');
   const afterHeader = e.chunks.length;
-  const bodyFrame: Frame = {
-    parent: frame,
-    mixins: collectMixins(node.rules),
-    declIndex: collectDeclIndex(node.rules), cells: null, reassign: null,
-    statements: node.rules
-  };
   e.depth++;
   const finish = (): void => {
     e.depth--;

--- a/packages/jess/test/less/structural-error-public-semantics.test.ts
+++ b/packages/jess/test/less/structural-error-public-semantics.test.ts
@@ -78,6 +78,29 @@ describe('Less structural errors through the public AST route', () => {
     ]);
   });
 
+  it('keeps an at-rule prelude lookup diagnostic at the same source position in both projections', async () => {
+    const source = '@media (min-width: @missing) {\n  .entry { color: red; }\n}';
+    const positions: Array<{ code: string; line: number; column: number }> = [];
+
+    for (const collapseNesting of [false, true]) {
+      const result = await new Compiler({ output: { collapseNesting } }).renderToResult({
+        source,
+        filePath: 'entry.less',
+        extension: '.less'
+      }, {
+        breakOnError: false,
+        suppressWarnings: true
+      });
+      const error = result.errors[0]!;
+      positions.push({ code: error.code, line: error.line!, column: error.column! });
+    }
+
+    expect(positions).toEqual([
+      { code: 'resolve/name-not-found', line: 1, column: 20 },
+      { code: 'resolve/name-not-found', line: 1, column: 20 }
+    ]);
+  });
+
   it.each(cases)('reports %s', async (_label, source, code) => {
     const compiler = new Compiler({ output: { collapseNesting: true } });
     await expect(compiler.renderString(source, {


### PR DESCRIPTION
## Why

V19 requires evaluation and lookup to depend only on the source stylesheet. Nesting is
an output projection. The serializer still had nested-only ruleset guard, extend-hoist,
and at-rule-prelude evaluators, so the two output modes could continue to drift at
container boundaries.

This is Slice 4 of the evaluator fold. It moves shared container, import, and hoist
responsibility without changing either projection's layout policy.

## What changed

- made `expandRule` the shared ruleset entry for guard evaluation and nested extend-hoist
  placement before calling the existing collapsed or nested writer
- deleted `emitNestedRule` and `emitNestedRuleGuarded`; the nested writer now consumes the
  shared result directly
- added `activateRuleFrame`, which reuses the existing render-local
  `Frame.rulePlacements` lifetime for ordinary rule activation in both projections
- made `expandAtRuleBlock` evaluate the prelude and construct the body frame once before
  selecting the resolved collapsed or nested writer; deleted `emitNestedAtRuleBlock`
- renamed the already-shared stylesheet import evaluator to `expandStyleImport`, making
  request/loading/reference-fact/source-order ownership explicit
- moved nested extend-hoist issuance to the shared ruleset entry and pinned it to one
  placement per crossing source rule
- removed the nested evaluator-side `e.collapse` read

The collapsed writer still owns selector composition, bubbling, partitioning, and flat
layout. The nested writer still owns authored selector text, indentation, coalescing, and
the extend-driven hoist projection. No AST/CST field, `Frame` field, context field,
projection carrier, event list, node mutation, or side table was added. Transient state
uses the existing short-lived `Frame`, `Emit`, placement-map, and writer-local queue
objects. `WeakMap` remains at five existing construction sites.

## Red-to-green and sensitivity evidence

- the test-only baseline named the duplicate container evaluators and failed the source
  ratchet until the nested helpers and collapse read were removed
- the nested-hoist budget initially observed zero because its first test fixture encoded
  selectors as opaque strings; the fixture was corrected to canonical structured
  selectors, after which the shared counter reads exactly 8 placements for N=8 and 16
  for N=16
- a disposable per-subject rescan raised the N=8 counter from 8 to 72 and failed the
  operation-budget test; the mutation was removed
- a disposable `span.start + 1` mutation moved lookup diagnostics in both projections
  from columns 10/20 to 11/21 and failed three exact-position assertions, including the
  new at-rule-prelude case; the mutation was removed

## Mechanical evidence

`serialize.ts` before/after: **16,988 -> 16,958 lines**.

| Surface | Before | After |
| --- | ---: | ---: |
| named functions | 417 | 415 |
| arrow functions | 579 | 577 |
| `mapMaybe` sites | 126 | 124 |
| `.then` sites | 105 | 105 |
| `new Map` | 57 | 56 |
| `new Set` | 34 | 34 |
| `new WeakMap` | 5 | 5 |
| `Frame` construction sites | 27 | 25 |
| leaf groups | 9 | 9 |
| evaluator-side `e.collapse` reads | 2 | 1 |

The remaining collapse read is the document-boundary writer selection assigned to Slice
5. The serializer still has two statement dispatchers; deleting the nested dispatcher is
also Slice 5.

## Correctness gates

- `pnpm run build:release`: green
- `packages/core`: **200 files; 3,199 passed, 8 skipped, 2 todo**
- Jess production ratchet: **1,425 tests, 0 failures**; current, gating, and flaky named
  failure sets exactly match the empty baseline
- normal all-less corpus: **112/112**
- forced `collapseNesting:true`: **111 before/after records**, byte-identical, SHA-256
  `ab837140229078bfd56a5ab47fe07dc26ceaf34b339f68e8adab67da4ec5499c`; its runner retains
  the known one golden mismatch caused by overriding a fixture-local nested option
- property-accessor and all selected both-mode suites: **74/74**
- `jess-plugin-less`: **14/14**
- `fns`: **718/718**
- `jess-plugin-scss`: **2/2**
- `pnpm run verify:aggressive-cutting-review`: green
- `pnpm run check:guardrails`: green
- touched-file lint and `git diff --check`: green
- prohibited additions (`as any`, `: any`, `@ts-ignore`, `@ts-nocheck`): **0**

`pnpm run verify:shape-stability` has the identical inherited result at the pre-slice and
candidate commits: the monomorphic AST assertion and all five CST assertions pass; the
stale AST corpus node-type inventory and `SpacedValue` allowlist assertions fail with the
same diffs. This slice changes no parser or canonical node shape.

## Performance

Standard `measure:less:hotpath` stable harness, same machine/session, Node 24.11.1,
Less test data 5.0.0-alpha.3 at `3af87fc0`, 100 iterations x 5 rounds. Medians are ms.

Collapsed projection, late paired pass:

| Fixture | Before | After | Delta | Signal |
| --- | ---: | ---: | ---: | --- |
| functions | 4.112 | 4.344 | +5.65% | both usable; same-head null moved +8.3% |
| import-reference | 6.886 | 6.660 | -3.27% | before unstable |
| mixins-guards | 4.456 | 4.277 | -4.03% | usable |
| extend-chaining | 1.114 | 1.065 | -4.39% | usable |
| media | 1.551 | 1.418 | -8.58% | usable |

Nested projection, late paired pass:

| Fixture | Before | After | Delta | Signal |
| --- | ---: | ---: | ---: | --- |
| functions | 3.661 | 3.739 | +2.13% | both unstable |
| import-reference | 6.456 | 6.279 | -2.74% | before unstable |
| mixins-guards | 4.452 | 4.238 | -4.79% | usable |
| extend-chaining | 1.033 | 1.015 | -1.78% | usable |
| media | 1.506 | 1.449 | -3.82% | after unstable |

The initial pair's apparent +6-7% `mixins-guards` movement reversed in both projections
on the paired rerun. Same-head candidate null runs moved individual fixtures by up to
13.4%, including +8.3% for collapsed `functions` and -7.1% for nested `mixins-guards`.
The harness cannot attribute a regression; no speed or neutrality claim is made.

## Review findings

- Semantics reviewer: approved invariants 1-8 and incident checks S1-S8. It verified
  V19/G28 alignment, identical at-rule diagnostic positions, unchanged writer policy,
  structured extend-plan consumption, and no new transient side table. No finding
  required a code change.
- Performance architecture reviewer: approved invariants 1-11 and catalogue checks R1-R8.
  It confirmed the existing call graph avoids a third `extendProjection` lookup, the
  crossing-hoist path improves from two lookups to one, allocation counts fall, both
  writers remain on `Emit.chunks`, and the timing evidence supports no attributable
  regression. No finding required a code change.

## What remains

Slice 5 deletes `emitNestedBody` and the second statement dispatcher, selects the writer
once at the serialization boundary, and takes evaluator-side collapse reads from one to
zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of at-rule prelude diagnostics: missing-name errors now report the same source location in both collapsed and expanded nesting modes.
  - Improved handling of nested rules, at-rules, imports, and extension hoists during stylesheet serialization.

- **Refactor**
  - Unified stylesheet expansion and writing paths to provide more consistent output across serialization modes.

- **Documentation**
  - Updated architecture documentation to reflect the latest shared evaluation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->