### PR TITLE
fix(grammar): accept spec-valid @container prelude forms in every dialect

### DIFF
--- a/packages/syntax/css/css-parser/src/grammar.ts
+++ b/packages/syntax/css/css-parser/src/grammar.ts
@@ -119,7 +119,10 @@ type GrammarRuleName =
   | 'ConditionalBlock'
   | 'ConditionalGroupAtRule'
   | 'ContainerPrelude'
+  | 'ContainerQueryAtom'
   | 'ContainerQueryClause'
+  | 'ContainerQueryCondition'
+  | 'ContainerQueryInParens'
   | 'ContainerQueryPrelude'
   | 'ConditionalAtKeyword'
   | 'ContainerAtKeyword'
@@ -3009,10 +3012,85 @@ const cssFactory = (g: GrammarSelf) => {
     not(containerNameReserved),
     g.Keyword
   );
+
+  /*
+   * A `<query-in-parens>` group: `( <container-query> )` (css-contain-3 §3,
+   * media-queries-5 §3.1). It carries the parenthesised boolean form the size
+   * and style features nest inside — `((width > 1px) and (height > 1px))` and
+   * `(style(--x: 1))`. This is the container analogue of `SupportsInParens` /
+   * `SupportsCondition` above, and is built on the SAME three atoms (a nested
+   * group, a size feature, a general-enclosed function) so a grouped
+   * `style(...)` reads through `Enclosed`'s balanced content model rather than
+   * the opaque `QueryFunction` scan, which — like the media prelude — cannot be
+   * nested inside another paren. The result wraps in the same `block(...)` a
+   * size-feature paren produces, matching what SCSS's `QueryInParens` emits.
+   * It is a deliberate sibling of `SupportsCondition`, not a factoring of it:
+   * the two share the `not`/`and`/`or`-in-parens skeleton but their atom sets
+   * differ (a supports atom is a declaration/selector; a container atom is a
+   * size feature or style query), so collapsing them would gate one at-rule's
+   * accept set on the other's.
+   *
+   * Tried FIRST in `ContainerQueryClause` below: its `( <condition> )` opens on
+   * a paren whose interior is a nested group, a feature or an enclosed function,
+   * none of which a bare `(width > 1px)` feature or a `style(...)` header matches,
+   * so those fall straight through to `QueryFeature` / `QueryFunction` and keep
+   * their shapes (the bare `style(...)` header stays a `QueryFunction`). Leading
+   * with the group also keeps `QueryFeature`'s value arm from speculatively
+   * reading a nested `fn(a: b)` as a component value and recording a stray error.
+   */
+  const ContainerQueryAtom = node(
+    'ContainerQueryAtom',
+    choice(
+      g.ContainerQueryInParens,
+      g.QueryFeature,
+      g.Enclosed
+    ),
+    children => firstValue(children)
+  );
+  const ContainerQueryCondition = node(
+    'ContainerQueryCondition',
+    choice(
+      sequence(
+        g.QueryNot,
+        g.ContainerQueryAtom
+      ),
+      sequence(
+        g.ContainerQueryAtom,
+        many(sequence(
+          g.QueryAndOr,
+          g.ContainerQueryAtom
+        ))
+      )
+    ),
+    (children) => {
+      const values: ValueNode[] = [];
+      for (const child of children) {
+        if (isValue(child)) {
+          values.push(child);
+        } else {
+          const normalized = tokenText(child).toLowerCase();
+          if (normalized === 'not' || normalized === 'and' || normalized === 'or') {
+            values.push(keyword(tokenText(child)));
+          }
+        }
+      }
+      return values.length === 1 ? values[0]! : spaced(values);
+    }
+  );
+  const ContainerQueryInParens = node(
+    'ContainerQueryInParens',
+    sequence(
+      literal('('),
+      g.ContainerQueryCondition,
+      literal(')')
+    ),
+    children => block(firstValue(children))
+  );
   const ContainerQueryClause = node(
     'ContainerQueryClause',
     sequence(
       choice(
+        g.ContainerQueryInParens,
         g.QueryFeature,
         g.QueryFunction
       ),
@@ -3812,6 +3890,9 @@ const cssFactory = (g: GrammarSelf) => {
     QueryClause,
     QueryPrelude,
     ContainerQueryClause,
+    ContainerQueryAtom,
+    ContainerQueryCondition,
+    ContainerQueryInParens,
     ContainerQueryPrelude,
     ContainerPrelude,
     QueryFunction,

--- a/packages/syntax/css/css-parser/test/byte-identity/fixtures/at-rules-conditional.css
+++ b/packages/syntax/css/css-parser/test/byte-identity/fixtures/at-rules-conditional.css
@@ -28,3 +28,18 @@
     color: teal;
   }
 }
+@container ((width > 1px) and (height > 1px)) {
+  a {
+    color: red;
+  }
+}
+@container style(--x: 1) {
+  a {
+    color: red;
+  }
+}
+@container (style(--x: 1)) {
+  a {
+    color: red;
+  }
+}

--- a/packages/syntax/jess/jess-parser/src/grammar.ts
+++ b/packages/syntax/jess/jess-parser/src/grammar.ts
@@ -264,6 +264,9 @@ type JessRules = {
   QueryClause: Combinator<ValueNode>;
   QueryPrelude: Combinator<ValueNode>;
   AtRulePrelude: Combinator<ValueNode | null>;
+  ContainerStyleQuery: Combinator<FunctionCall>;
+  ContainerQueryInParens: Combinator<ValueNode>;
+  ContainerQueryAtom: Combinator<ValueNode>;
   ContainerQueryClause: Combinator<ValueNode>;
   ContainerQueryPrelude: Combinator<ValueNode>;
   ContainerPrelude: Combinator<ValueNode>;
@@ -3390,17 +3393,101 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
     ['none'],
     { boundary: '-_a-zA-Z0-9\\u0080-\\uFFFF', caseInsensitive: true }
   );
+
+  /*
+   * A bare container name is one `<custom-ident>`, never the head of a query
+   * function: `style(--x: 1)` is a `<style-query>`, not a container named
+   * `style` followed by a stray group. Guarding on `<ident>(` keeps that
+   * function form on the query path, matching the css base's `not(QueryFunctionOpen)`.
+   */
+  const containerFunctionOpen = noTrivia(sequence(
+    g.Identifier,
+    literal('(')
+  ));
   const containerName = sequence(
+    not(containerFunctionOpen),
     not(containerNameReserved),
     g.Keyword
+  );
+
+  /*
+   * A `<style-query>` container header, `style(--x: 1)` (css-contain-3 §3.3).
+   * The opener is one token so `style(` cannot split across whitespace, and the
+   * argument is the same structural custom-property comparison the other
+   * dialects build — `funcCall('style', [Operation(':', <name>, <value>)])`,
+   * matching Less rather than an opaque header slice.
+   */
+  const jessStyleFunctionOpener = token(noTrivia(sequence(
+    word(
+      'style',
+      '-_a-zA-Z0-9\\u0080-\\uFFFF',
+      { caseInsensitive: true }
+    ),
+    literal('(')
+  )));
+  const ContainerStyleQuery = node<FunctionCall>(
+    'ContainerStyleQuery',
+    sequence(
+      jessStyleFunctionOpener,
+      g.CustomPropertyName,
+      literal(':'),
+      g.QueryValue,
+      literal(')')
+    ),
+    children => funcCall(
+      'style',
+      [operation(
+        ':',
+        keyword(requireToken(children[1]).value),
+        requireValueNode(children[3]),
+        false,
+        cssBaseMathOutsideParens(':')
+      )]
+    )
+  );
+
+  /*
+   * A `<query-in-parens>` group: `( <container-query> )` (css-contain-3 §3,
+   * media-queries-5 §3.1). Carries the parenthesised boolean form the features
+   * nest inside — `((width > 1px) and (height > 1px))`, `(style(--x: 1))` — and
+   * recurses through the clause so an inner `and`/`or` chain or a style query
+   * stays one grouped condition wrapped in `block(...)`, as css/less/scss emit.
+   */
+  const ContainerQueryInParens = node<ValueNode>(
+    'ContainerQueryInParens',
+    sequence(
+      literal('('),
+      g.ContainerQueryClause,
+      literal(')')
+    ),
+    children => block(requireValueNode(children[1]))
+  );
+
+  /*
+   * One `<container-query>` operand: a nested parenthesised group, a size
+   * feature, or a style query. The group is tried FIRST: a bare `(width > 1px)`
+   * feature or `style(...)` header has no leading `(`-then-`(`/`(`-then-fn, so it
+   * falls straight through to QueryFeature / ContainerStyleQuery, while leading
+   * with the group keeps QueryFeature's value-first range arm from speculatively
+   * reading a nested `style(--x: 1)` as a component value and recording a stray
+   * error (the same ordering the css base uses for its query-in-parens group).
+   */
+  const ContainerQueryAtom = node<ValueNode>(
+    'ContainerQueryAtom',
+    choice(
+      g.ContainerQueryInParens,
+      g.QueryFeature,
+      g.ContainerStyleQuery
+    ),
+    children => requireValueNode(children[0])
   );
   const ContainerQueryClause = node<ValueNode>(
     'ContainerQueryClause',
     sequence(
-      g.QueryFeature,
+      g.ContainerQueryAtom,
       many(sequence(
         g.QueryAndOr,
-        g.QueryFeature
+        g.ContainerQueryAtom
       ))
     ),
     (children) => {
@@ -5339,6 +5426,9 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
     QueryClause,
     QueryPrelude,
     AtRulePrelude,
+    ContainerStyleQuery,
+    ContainerQueryInParens,
+    ContainerQueryAtom,
     ContainerQueryClause,
     ContainerQueryPrelude,
     ContainerPrelude,

--- a/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
+++ b/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
@@ -1635,11 +1635,24 @@ describe('Jess AST grammar facts', () => {
     });
     for (const rejected of [
       '@media (width >= $limit) { .card { color: blue; } }',
-      '@media (width < 80rem < 100rem) { .card { color: blue; } }',
-      '@container style(--theme: dark) { .card { color: blue; } }'
+      '@media (width < 80rem < 100rem) { .card { color: blue; } }'
     ]) {
       expect(() => parse(rejected), rejected).toThrow(SyntaxError);
     }
+
+    /*
+     * css-contain-3 §3.3 `<style-query>`: a typed container-header function, the
+     * structured `funcCall('style', [Operation(':', <name>, <value>)])` the other
+     * dialects build — not a widened opaque header.
+     */
+    expect(parse('@container style(--theme: dark) { .card { color: blue; } }').rules[0]).toMatchObject({
+      type: 'AtRuleBlock',
+      prelude: {
+        type: 'FunctionCall',
+        name: 'style',
+        args: [{ value: { type: 'Operation', operator: ':' } }]
+      }
+    });
   });
 
   it('constructs a media feature <ratio> value in every static query form', () => {

--- a/packages/syntax/less/less-parser/src/grammar.ts
+++ b/packages/syntax/less/less-parser/src/grammar.ts
@@ -286,6 +286,7 @@ type LessRules = {
   ContainerScrollStateQuery: Combinator<FunctionCall>;
   ContainerName: Combinator<Keyword>;
   ContainerQueryAtom: Combinator<ValueNode>;
+  ContainerQueryInParens: Combinator<ValueNode>;
   ContainerCondition: Combinator<ValueNode>;
   MediaContainerBody: Combinator<readonly Statement[]>;
   MediaContainerBlock: Combinator<AtRuleBlock>;
@@ -3382,9 +3383,29 @@ const lessGrammarFactory = (g: LessInputRules & SharedSyntax) => {
     ),
     children => requireKeyword(children.at(-1))
   );
+  // A `<query-in-parens>` wrapping a single `<container-query>` operand —
+  // `(style(--x: 1))`, `((width > 1px))`, `(scroll-state(--x: 1))`
+  // (css-contain-3 §3, media-queries-5 §3.1). The inner is ONE atom, never an
+  // `and`/`or` chain, so the boolean group `((a) and (b))` and the negated form
+  // `(not (a))` still fall through to QueryFeature's QueryLogicalGroup /
+  // QueryNegatedFeature owners below (after the leading `(` there `and`/`or`/`not`
+  // is what the chain needs and this single-atom arm cannot supply). Tried FIRST
+  // in ContainerQueryAtom so QueryFeature's value-first range arm never
+  // speculatively reads the nested `style(--x: 1)` as a component value.
+  const ContainerQueryInParens = node(
+    'ContainerQueryInParens',
+    sequence(literal('('), choice(
+      g.ContainerStyleQuery,
+      g.ContainerScrollStateQuery,
+      g.QueryFeature,
+      g.ContainerQueryInParens
+    ), literal(')')),
+    children => block(requireValueNode(children[1]))
+  );
   const ContainerQueryAtom = node(
     'ContainerQueryAtom',
     choice(
+      g.ContainerQueryInParens,
       g.ContainerStyleQuery,
       g.ContainerScrollStateQuery,
       g.QueryFeature
@@ -4853,6 +4874,7 @@ const lessGrammarFactory = (g: LessInputRules & SharedSyntax) => {
     ContainerScrollStateQuery,
     ContainerName,
     ContainerQueryAtom,
+    ContainerQueryInParens,
     ContainerCondition,
     MediaContainerBody,
     MediaContainerBlock,

--- a/test/cross-dialect/acceptance-matrix.test.ts
+++ b/test/cross-dialect/acceptance-matrix.test.ts
@@ -131,14 +131,6 @@ const DIRECTION_1_ALLOWLIST: readonly Allowed[] = [
       + 'layer statement.'
   },
   {
-    name: 'targeted:@container style()',
-    accepted: ['css', 'less', 'scss'],
-    validCss: true,
-    reason:
-      'css-contain-3 §5.2 defines style queries — `@container style(--x: 1) { … }` is valid CSS. '
-      + 'jess refuses it. Defect in jess: no style() arm in its container query condition.'
-  },
-  {
     name: 'targeted:@page with a pseudo',
     accepted: ['css', 'less', 'scss'],
     validCss: true,

--- a/test/css-superset-corpus.ts
+++ b/test/css-superset-corpus.ts
@@ -202,30 +202,17 @@ export const CSS_CONSTRUCTS: readonly CssConstruct[] = [
   {
     id: '@container with a parenthesised condition group',
     group: 'at-rule',
-    source: '@container ((width > 1px) and (height > 1px)) { a { color: red } }',
-    brokenIn: ['css', 'jess'],
-    defect:
-      'css-contain-3 §3 makes `<container-condition>` a `<boolean-expr>`, whose '
-      + 'general form permits a parenthesised group. Less and SCSS accept it; CSS '
-      + 'and Jess reject it, so the BASE dialect is stricter than two supersets — '
-      + 'the one-way ruling inverted.'
+    source: '@container ((width > 1px) and (height > 1px)) { a { color: red } }'
   },
   {
     id: '@container with style()',
     group: 'at-rule',
-    source: '@container style(--x: 1) { a { color: red } }',
-    brokenIn: ['jess'],
-    defect: 'Jess rejects the css-contain-3 §3.3 `<style-query>` that the other three accept.'
+    source: '@container style(--x: 1) { a { color: red } }'
   },
   {
     id: '@container with a parenthesised style()',
     group: 'at-rule',
-    source: '@container (style(--x: 1)) { a { color: red } }',
-    brokenIn: ['css', 'less', 'jess'],
-    defect:
-      'Only SCSS accepts the parenthesised style query. Same root as the '
-      + 'condition-group entry above: the boolean-expression parens are missing '
-      + 'from three container preludes.'
+    source: '@container (style(--x: 1)) { a { color: red } }'
   },
   {
     id: '@keyframes with percentage and to selectors',


### PR DESCRIPTION
Three `@container` prelude forms are valid CSS (css-contain-3 §3 `<query-in-parens>`, §3.3 `<style-query>`) but were rejected by one or more dialects, so a stylesheet using them failed to compile. They now parse and serialize identically in **all four** dialects.

## What changes

| Input | Before | After |
| --- | --- | --- |
| `@container ((width > 1px) and (height > 1px)) { … }` | rejected in **css, jess** | accepted everywhere |
| `@container style(--x: 1) { … }` | rejected in **jess** | accepted everywhere |
| `@container (style(--x: 1)) { … }` | rejected in **css, less, jess** | accepted everywhere |
| `@container ((width > 1px)) { … }` (single feature group) | rejected in **less** | accepted everywhere |

Emitted CSS is byte-identical to the authored source for every form.

## How

- **css base** gains a `<query-in-parens>` group built on the same shape the existing `@supports` prelude already uses (`SupportsInParens` / `SupportsCondition`). A grouped `style(...)` reads through the balanced general-enclosed content model rather than the opaque query-function scan, which cannot nest inside another paren. The group is tried first in the container clause so a plain `(width > 1px)` still routes to the feature rule and a nested `style(--x: 1)` is never speculatively read as a component value.
- **less** adds a narrow parenthesised-query arm for the one form it rejected — a single parenthesised query (`(style(…))`, `((width > 1px))`) — while its existing `QueryLogicalGroup` / `QueryNegatedFeature` keep ownership of `and`/`or` groups and negated features (unchanged output).
- **jess** gains a structured `style( <custom-prop> : <value> )` query, the group, and a `not(<ident>( )` guard on the container name so `style(…)` routes to the query path instead of being misread as a container named `style`.
- Bare `style(...)` / `scroll-state(...)` headers keep their existing node shapes.

The previously-pinned corpus and rejection assertions for these forms are flipped to acceptance contracts, and the three css forms are added to the byte-identity fixture so their emission stays locked.

## Verification

- Four parser suites green: css 515, less 741, scss 622, jess 510.
- css byte-identity oracle green (6), with the three new forms added — 0 AST moves on the existing corpus.
- `packages/core` 3262, `fns` 718, `language-service` 264 green; `packages/jess` ratchet matches baseline exactly (1425, 0 failing).
- `check:{macro,compose-fused,reducer-purity,guardrails}` all green; parsers fully macro-compile with 0 interpreter fallbacks.

## Note

`test/cross-dialect/acceptance-matrix.test.ts` has one **pre-existing** failing row — `escape.css :: [css] → [css, jess]` — that is independent of this change: this diff touches only `@container` prelude productions, and `escape.css` contains no `@container`, so jess's handling of it is byte-for-byte unchanged here. This PR removes one now-stale matrix entry (`@container style()`), reducing that test's divergence set; the `escape.css` row needs its own investigation.
