### PR TITLE
fix(grammar): accept a leading combinator in jess selector-pseudo arguments

### DIFF
--- a/packages/syntax/jess/jess-parser/src/grammar.ts
+++ b/packages/syntax/jess/jess-parser/src/grammar.ts
@@ -1903,6 +1903,7 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
     literal('+'),
     literal('~')
   );
+
   /*
    * `:nth-child`/`:nth-last-child` argument: a bare `<An+B>` OR `<An+B> of S`
    * (Selectors-4 §6.6.2, https://www.w3.org/TR/selectors-4/#the-nth-child-pseudo).

--- a/packages/syntax/jess/jess-parser/src/grammar.ts
+++ b/packages/syntax/jess/jess-parser/src/grammar.ts
@@ -1893,6 +1893,17 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
   );
 
   /*
+   * A relative-selector combinator (`>`/`+`/`~`, never the column `||` or
+   * namespace `|`): selectors-4 §4.2 lets a `:has()` argument branch open with
+   * one. Folded into `PseudoSelectorComplex` (below), guarded out of the nth
+   * bare-selector fallback, and reused by the CSS Nesting `RelativeSelector`.
+   */
+  const relativeSelectorCombinator = choice(
+    literal('>'),
+    literal('+'),
+    literal('~')
+  );
+  /*
    * `:nth-child`/`:nth-last-child` argument: a bare `<An+B>` OR `<An+B> of S`
    * (Selectors-4 §6.6.2, https://www.w3.org/TR/selectors-4/#the-nth-child-pseudo).
    * The shared `g.NthExpression`/`g.NthOfKeyword`/`g.PseudoSelectorCloseAhead`
@@ -1921,7 +1932,14 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
             )),
             g.PseudoSelectorCloseAhead
           ),
-          g.PseudoSelectorList
+
+          /*
+           * The bare selector fallback (`:nth-child(.a)`) is not a relative
+           * selector: a leading combinator makes it an invalid `<An+B>`
+           * (`:nth-child(+ n)`), so reject rather than re-capturing `+ n` now
+           * that `PseudoSelectorComplex` admits a leading combinator.
+           */
+          sequence(not(relativeSelectorCombinator), g.PseudoSelectorList)
         )
       )
     ),
@@ -1964,6 +1982,13 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
               g.NthOfKeyword
             )
           )),
+
+          /*
+           * Same guard as `:nth-child`: the bare selector fallback is not a
+           * relative selector, so a leading combinator (`:nth-of-type(+ n)`)
+           * rejects rather than parsing as `+ n`.
+           */
+          not(relativeSelectorCombinator),
           g.PseudoSelectorList
         )
       )
@@ -2088,9 +2113,20 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
     literal('+'),
     literal('~')
   );
+
+  /*
+   * A functional-pseudo argument branch may open with a relative combinator
+   * (`:has(> .b)`, selectors-4 §4.2). css/less/scss all admit it; jess matches by
+   * folding an optional leading combinator into this complex, emitting a
+   * `RelativeSelector` when present and a bare branch otherwise — the same shape
+   * as less's `PseudoArgumentComplex`. This complex is also the nth argument's
+   * selector fallback, so the two callers there guard the leading combinator out:
+   * `:nth-child(+ n)` is an invalid `<An+B>`, not a relative selector.
+   */
   const PseudoSelectorComplex = node<SelectorBranch>(
     'PseudoSelectorComplex',
     sequence(
+      optional(relativeSelectorCombinator),
       g.PseudoSelectorCompound,
       many(sequence(
         optional(selectorCombinator),
@@ -2098,6 +2134,13 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
       ))
     ),
     (children) => {
+      /*
+       * Position 0 is the optional leading combinator token, or the first
+       * compound (a `SelectorTerm`, never a token) when absent — so `isToken`
+       * alone identifies a relative branch without restating the combinator set.
+       */
+      const first = children[0];
+      const lead = isToken(first) ? first : undefined;
       const segments: Array<{ combinator?: JessComplexTail['combinator']; term: SelectorTerm }> = [];
       let combinator: JessComplexTail['combinator'] = ' ';
       for (const child of children) {
@@ -2110,7 +2153,8 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
           combinator = jessCombinator(child);
         }
       }
-      return selectorBranchOf([segments[0]!, ...segments.slice(1)]);
+      const branch = selectorBranchOf([segments[0]!, ...segments.slice(1)]);
+      return lead === undefined ? branch : relativeSelector(jessRelativeCombinator(lead), jessBranchSegments(branch));
     }
   );
   const PseudoSelectorTail = node<SelectorBranch>(
@@ -2138,7 +2182,7 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
 
   /*
    * The generic (non-nth) functional-pseudo argument: a static `SelectorList`
-   * only (`:not(.a, .b)`, `:is(.a)`, `:lang(en)`). The nth families dispatch by
+   * only (`:not(.a, .b)`, `:is(.a)`, `:has(> .b)`). The nth families dispatch by
    * name to their own arguments above; CSS's generic raw pseudo-argument arm is
    * deliberately NOT used here — it would hide dynamic Jess interpolation as
    * source text. Retain the parsed `SelectorList` rather than collapsing it to
@@ -5175,13 +5219,10 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
    * parent (`.parent > .child`). This reuses `g.ComplexSelector` behind an
    * optional leading `>`/`+`/`~`, yielding a `RelativeSelector` when the
    * combinator is present and a bare `ComplexSelector` otherwise. Mirrors css's
-   * `RelativeSelector` (css `grammar.ts`) and scss's `RelativeSelector`.
+   * `RelativeSelector` (css `grammar.ts`) and scss's `RelativeSelector`. The
+   * `relativeSelectorCombinator` it opens with is shared with the functional-
+   * pseudo argument (defined above with the nth/pseudo selector rules).
    */
-  const relativeSelectorCombinator = choice(
-    literal('>'),
-    literal('+'),
-    literal('~')
-  );
   const RelativeSelector = node<SelectorBranch>(
     'RelativeSelector',
     sequence(

--- a/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
+++ b/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
@@ -1103,6 +1103,44 @@ describe('Jess AST grammar facts', () => {
     }
   });
 
+  it('accepts a leading combinator in a selector-pseudo argument (selectors-4 §4.2)', () => {
+    /*
+     * A `:has()` argument is a `<relative-selector-list>`, so a branch may open
+     * with a combinator (`:has(> .b)`). css/less/scss all admit a leading
+     * combinator on the shared selector-pseudo argument; Jess converges to that
+     * shape, keeping the branch as a structured `RelativeSelector` in `args`.
+     */
+    expect(parse('.x:has(> .b) { color: red; }')).toMatchObject({
+      type: 'Stylesheet',
+      rules: [{
+        type: 'Ruleset',
+        selector: {
+          type: 'SelectorList',
+          selectors: [{
+            type: 'CompoundSelector',
+            value: [
+              { text: '.x' },
+              {
+                type: 'PseudoSelector',
+                name: ':has',
+                args: { type: 'SelectorList', selectors: [{ type: 'RelativeSelector', value: ['>', { text: '.b' }] }] }
+              }
+            ]
+          }]
+        }
+      }]
+    });
+
+    // The structured relative branch serializes back byte-identically.
+    for (const [source, expected] of [
+      ['.x:has(> .b) { color: red; }', '.x:has(> .b) {\n  color: red;\n}\n'],
+      ['.x:has(+ .b) { color: red; }', '.x:has(+ .b) {\n  color: red;\n}\n'],
+      ['.x:has(~ .b) { color: red; }', '.x:has(~ .b) {\n  color: red;\n}\n']
+    ] as const) {
+      expect(serialize(parse(source)).css, source).toEqual(expected);
+    }
+  });
+
   it('rejects paren-less nth pseudo names at the identifier boundary (cross-dialect divergence unification)', () => {
     /*
      * A bare, paren-less nth name is not a keyword pseudo — it must reach the

--- a/packages/syntax/jess/jess-parser/test/discovered-constructs.test.ts
+++ b/packages/syntax/jess/jess-parser/test/discovered-constructs.test.ts
@@ -130,15 +130,15 @@ describe('Jess constructs discovered outside the parser suites', () => {
 
   it.each([
     ['child', 'a:has(> .b){c:d}'],
-    ['next sibling', 'a:has(+ .b){c:d}']
-  ])('PINNED DEFECT — rejects a leading combinator in a relative selector (%s)', (_label, source) => {
+    ['next sibling', 'a:has(+ .b){c:d}'],
+    ['subsequent sibling', 'a:has(~ .b){c:d}']
+  ])('accepts a leading combinator in a relative selector (%s)', (_label, source) => {
     /*
-     * selectors-4 §4.2: a relative selector may start with a combinator.
-     * CSS, Less and SCSS all accept `:has(> .b)`; only Jess does not, and it
-     * is plain CSS, so this is a Jess selector-grammar gap rather than a
-     * dialect decision.
+     * selectors-4 §4.2: a relative selector may start with a combinator. CSS,
+     * Less and SCSS all admit a leading combinator on the shared selector-pseudo
+     * argument, and it is plain CSS, so Jess accepts it too.
      */
-    expect(() => parse(source)).toThrow();
+    expect(() => parse(source)).not.toThrow();
   });
 
   it('accepts an A+B microsyntax with no spaces around the sign', () => {


### PR DESCRIPTION
## What changes

A functional selector-pseudo argument in `.jess` may now open with a combinator, matching CSS, Less and SCSS. Per selectors-4 §4.2 a `:has()` argument is a `<relative-selector-list>`, whose branches may start with `>`, `+` or `~`.

Before → after (`.jess`):

| Input | Before | After |
| --- | --- | --- |
| `a:has(> .b) { c: d }` | parse error | `a:has(> .b) { c: d }` |
| `a:has(+ .b) { c: d }` | parse error | `a:has(+ .b) { c: d }` |
| `a:has(~ .b) { c: d }` | parse error | `a:has(~ .b) { c: d }` |

This is plain CSS, so it should never have failed in `.jess` alone; the other three dialects already accepted it.

## How

An optional leading combinator is folded into the shared selector-pseudo argument branch (`PseudoSelectorComplex`), producing the same structured `RelativeSelector` node the other dialects emit, so it serializes back byte-identically. As in those dialects the shared branch admits the leading combinator for every selector pseudo (`:is`/`:where`/`:not`/`:matches`), not only `:has()`.

Because that branch is also the `:nth-child()`/`:nth-of-type()` bare-selector fallback, a leading combinator is guarded out there, so `:nth-child(+ n)` still rejects — a leading combinator makes it an invalid `<An+B>`, not a relative selector.

## Tests / verification

- Flipped the two previously-failing `:has(> .b)` / `:has(+ .b)` cases to acceptance and added `:has(~ .b)`; added an AST-shape + byte-identical serialization test for `:has(> .b)`.
- Parser suites: css 515, less 741, scss 622, jess 512 — all pass.
- Byte-identity oracle (jess): AST and CST byte-identical before/after on the existing corpus (0/148 moved); the newly-accepted forms are the only behavioral delta.
- `check:macro` (jess fully compiled, 0 interpreter fallbacks), `check:compose-fused`, `check:reducer-purity`, `check:guardrails` all green.
- core 3262, fns 718, language-service 264 pass; jess ratchet pass set matches baseline exactly (1425, 0 failing); `verify:types` 24/24.
- Parse-time medians within noise (mixed direction, inconclusive).
