### PR TITLE
fix(scss): keep the whole star-hack property name

### DIFF
--- a/packages/syntax/scss/scss-parser/src/grammar.ts
+++ b/packages/syntax/scss/scss-parser/src/grammar.ts
@@ -422,10 +422,13 @@ const scssFactory = (g: ScssInputRules) => {
    * CSS owns the ordinary property identifier. SCSS adds only the legacy `*`
    * declaration hack, so this is a disjoint two-arm extension rather than a
    * copied identifier regex. Keep the starred arm trivia-free: `* color` is
-   * not one property name.
+   * not one property name. `token(...)` collapses `*` + ident into ONE token so
+   * `*color` is the whole property name (`Declaration{name:'*color'}`), matching
+   * Less's `DeclarationPropertyToken`; without it the reducer reads only the `*`
+   * child and silently drops the ident.
    */
   const propertyIdentifier = choice(
-    noTrivia(sequence(literal('*'), g.Identifier)),
+    token(noTrivia(sequence(literal('*'), g.Identifier))),
     g.Identifier
   );
 

--- a/packages/syntax/scss/scss-parser/test/discovered-constructs.test.ts
+++ b/packages/syntax/scss/scss-parser/test/discovered-constructs.test.ts
@@ -89,16 +89,34 @@ describe('SCSS constructs discovered outside the parser suites', () => {
     });
   });
 
-  it('PINNED DEFECT — drops the property name off a star-hack declaration', () => {
+  it('keeps the whole property name on a star-hack declaration', () => {
     /*
-     * `*color: red` must reach the AST with `name: "*color"` — the leading
-     * `*` is an IE hack that is part of the property name, and Less produces
-     * exactly that. SCSS instead produces `name: "*"` with `red` as the
-     * value, silently discarding `color`. This is data loss, not a rejection,
-     * which is why it went unnoticed: the parse "succeeds".
+     * `*color: red` reaches the AST with `name: "*color"` — the leading `*` is
+     * an IE hack that is part of the property name, and Less produces exactly
+     * that (G31 / pinned-defect D16). SCSS formerly produced `name: "*"` with
+     * `color` silently discarded; `token(...)` around the starred property arm
+     * now collapses `*color` into one property-name token.
      */
     expect(firstRule('a{*color:red}')).toMatchObject({
-      rules: [{ type: 'Declaration', name: '*', value: { type: 'Keyword', src: 'red' } }]
+      rules: [{ type: 'Declaration', name: '*color', value: { type: 'Keyword', src: 'red' } }]
+    });
+  });
+
+  it('keeps the whole property name on other star-hack properties', () => {
+    expect(firstRule('a{*width:1px}')).toMatchObject({
+      rules: [{ type: 'Declaration', name: '*width', value: { type: 'Dimension' } }]
+    });
+  });
+
+  it('leaves an ordinary property name unstarred', () => {
+    expect(firstRule('a{color:red}')).toMatchObject({
+      rules: [{ type: 'Declaration', name: 'color', value: { type: 'Keyword', src: 'red' } }]
+    });
+  });
+
+  it('keeps a custom property name intact', () => {
+    expect(firstRule('a{--x:red}')).toMatchObject({
+      rules: [{ type: 'Declaration', name: '--x' }]
     });
   });
 


### PR DESCRIPTION
## What

SCSS dropped part of a legacy IE star-hack property name. Given

```scss
a { *color: red }
```

the parser produced `Declaration{ name: "*" }` and silently discarded
`color` — the parse "succeeded" while losing data. It now produces
`Declaration{ name: "*color" }`, keeping the whole property name (Less
already does this; plain CSS rejects the star hack outright).

## Why

The SCSS property-name production matched the starred form as two separate
tokens — `*` and the identifier — but every reducer that consumes a
property name reads it from a single `children[0]` token. So only the `*`
survived and the identifier was thrown away.

## How

Wrap the starred property arm in `token(...)` so `*color` collapses into
one property-name token, exactly as Less's `DeclarationPropertyToken`
(`optional('*')` + ident, wrapped in `token`) already does. The ordinary
property path and custom properties (`--x`) are untouched — the wrapper
sits only on the star arm.

```
- token: literal('*'), g.Identifier   →   token( literal('*'), g.Identifier )
```

## Tests

- The star-hack case in `scss-parser/test/discovered-constructs.test.ts`
  now asserts `name: "*color"` (was a pinned wrong answer). Added positive
  regression guards: `*width` keeps its name, a plain `color` stays
  unstarred, and `--x` custom properties are intact.
- Full scss-parser suite: 625 pass.
- SCSS byte-identity oracle, isolated before/after over the same build:
  exactly one corpus entry moves — the star-hack fixture
  `declaration-star-property.css` — on both AST and CST surfaces, with the
  `threw` counts unchanged. Every other entry is byte-identical. That one
  move is the recovered name; nothing else shifts.
- Downstream green: core (3262), fns (718), language-service (264), and the
  jess render baseline (1425, pass set matches exactly).
- Parse perf over a declaration-heavy input is unchanged (median ~15.15ms
  before vs ~15.14ms after) — the ordinary path is byte-identical and the
  star arm only collapses two tokens into one.
