### PR TITLE
fix(jess-parser): accept css-syntax-3 escapes in unquoted url() bodies

### DIFF
--- a/packages/syntax/jess/jess-parser/src/grammar.ts
+++ b/packages/syntax/jess/jess-parser/src/grammar.ts
@@ -741,8 +741,14 @@ const plainUrlInner = regex(/(?:[^"'()\\$ \t\n\r\f\x00-\x08\x0B\x0E-\x1F\x7F]|\\
  * segment. Every other `$` remains CSS URL-token text, so `$foo` and
  * `$[key]` do not become Jess value lookups. Whitespace, quotes, and
  * parentheses stay outside this closed URL slice.
+ *
+ * `\\` is excluded from the plain-character class so a backslash can only start
+ * the css-syntax-3 §4.3.6 escape alternative, exactly as `plainUrlInner` and the
+ * shared css `urlInner` do. Otherwise `url(a\ b.png)` / `url(a\)b.png)` would
+ * read the backslash as literal text and stop at the following escaped space or
+ * paren — valid CSS the base dialects accept.
  */
-const unquotedUrlText = regex(/(?:[^"'()$\ \t\n\r\f\x00-\x08\x0B\x0E-\x1F\x7F]|\$(?!\{)|\\(?:[0-9a-fA-F]{1,6}[ \t\n\r\f]?|[^\n\r\f]))+/);
+const unquotedUrlText = regex(/(?:[^"'()\\$ \t\n\r\f\x00-\x08\x0B\x0E-\x1F\x7F]|\$(?!\{)|\\(?:[0-9a-fA-F]{1,6}[ \t\n\r\f]?|[^\n\r\f]))+/);
 
 /*
  * Jess's compiler namespace: the `@-\u2026` names a module directive lowers to. They

--- a/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
+++ b/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
@@ -775,6 +775,24 @@ describe('Jess AST grammar facts', () => {
     });
   });
 
+  it('keeps css-syntax-3 §4.3.6 escapes inside an unquoted url() body', () => {
+    /*
+     * `\ ` and `\)` are ordinary escaped code points in an unquoted url-token,
+     * so the base css/less/scss dialects accept them and Jess must too. The
+     * escaped bytes stay verbatim in the Url payload.
+     */
+    expect(parse('a { background: url(a\\ b.png) }')).toMatchObject({
+      rules: [{ type: 'Ruleset', rules: [
+        { name: 'background', value: { type: 'Url', value: { type: 'Any', src: 'a\\ b.png' } } }
+      ] }]
+    });
+    expect(parse('a { background: url(a\\)b.png) }')).toMatchObject({
+      rules: [{ type: 'Ruleset', rules: [
+        { name: 'background', value: { type: 'Url', value: { type: 'Any', src: 'a\\)b.png' } } }
+      ] }]
+    });
+  });
+
   it('reads a collection member in condition position exactly as in value position', () => {
     const source = '$c: { x: 4px; }; $if ($c.x > 0) { .a { width: $($c.x * 2); } }';
     expect(parse(source)).toMatchObject({

--- a/test/css-superset-corpus.ts
+++ b/test/css-superset-corpus.ts
@@ -590,19 +590,12 @@ export const CSS_CONSTRUCTS: readonly CssConstruct[] = [
   {
     id: 'url() with an escaped space',
     group: 'value',
-    source: 'a { background: url(a\\ b.png) }',
-    brokenIn: ['jess'],
-    defect:
-      'css-syntax-3 §4.3.6 consumes a url-token with escapes, so `\\ ` and '
-      + '`\\)` are ordinary escaped code points inside an unquoted url. Jess '
-      + 'rejects both.'
+    source: 'a { background: url(a\\ b.png) }'
   },
   {
     id: 'url() with an escaped close paren',
     group: 'value',
-    source: 'a { background: url(a\\)b.png) }',
-    brokenIn: ['jess'],
-    defect: 'Same defect as the escaped-space url() above.'
+    source: 'a { background: url(a\\)b.png) }'
   },
   {
     id: 'attr() bare',


### PR DESCRIPTION
## What

Unquoted `url()` bodies in the Jess parser now accept css-syntax-3 §4.3.6
escapes. `url(a\ b.png)` and `url(a\)b.png)` parse and emit; before this change
they failed to parse, even though CSS, Less, and SCSS all accept them.

## Why

The value-position unquoted-url recognizer (`unquotedUrlText` in
`packages/syntax/jess/jess-parser/src/grammar.ts`) omitted the backslash from
its negated plain-character class:

```
before: [^"'()$ \t\n\r\f…]   ->  a backslash matches as an ordinary char
after:  [^"'()\\$ \t\n\r\f…] ->  a backslash can only open the escape branch
```

With the backslash treated as ordinary text, `url(a\ b.png)` consumed `a\`,
then hit the escaped space, treated it as a value separator, and the URL failed
to close. Excluding the backslash routes it into the escape alternative the
regex already carried (`\\(?:[0-9a-fA-F]{1,6}[ \t\n\r\f]?|[^\n\r\f])`), so the
escaped space or paren is consumed as one code point.

This is the same shape the base css url token
(`packages/parser-shared/src/recognition.ts`) and the sibling at-rule url token
(`plainUrlInner`, same file) already use — the Jess value-position token was the
only one missing the exclusion. The `${…}` interpolation boundary (`\$(?!\{)`)
is untouched: `a${` still stops at `a`, `a$foo` still matches whole.

## Input -> output

| Input | Before | After |
| --- | --- | --- |
| `url(a\ b.png)` | parse error | `Url { value: Any "a\ b.png" }` |
| `url(a\)b.png)` | parse error | `Url { value: Any "a\)b.png" }` |
| `url(a/b.png)` | ok | ok (unchanged) |
| `url(${p}/b.png)` | ok | ok (unchanged) |

The escaped bytes are preserved verbatim in the `Url` payload — no unescaping,
no re-derivation.

## Tests

- `test/css-superset-corpus.ts`: the two escaped-url constructs are no longer
  marked broken in `jess`; they are now acceptance contracts for all four
  dialects.
- `packages/syntax/jess/jess-parser/test/ast-grammar.test.ts`: a positive
  AST-shape assertion for both escaped-url forms.

## Verification

- jess-parser suite: 524 pass
- packages/core: 3262 pass · packages/fns: 718 pass · language-service: 264 pass
- packages/jess ratchet: 1425 tests, 0 failing, pass set matches baseline exactly
- jess byte-identity oracle: IDENTICAL across 148 corpus files (no `.jess`/`.css`
  corpus file exercises the escaped-url path, so no existing tree moves)
- `check:macro`, `check:compose-fused`, `check:reducer-purity`,
  `check:guardrails`: all green
- Parse-bench medians before/after are within run-to-run noise (single character
  added to one negated character class)
