### PR TITLE
fix(jess): accept dotted @layer sub-layer names

### DIFF
--- a/packages/syntax/jess/jess-parser/src/grammar.ts
+++ b/packages/syntax/jess/jess-parser/src/grammar.ts
@@ -264,6 +264,7 @@ type JessRules = {
   QueryDashedIdentifier: Combinator<Keyword>;
   QueryClause: Combinator<ValueNode>;
   QueryPrelude: Combinator<ValueNode>;
+  DottedAtRuleKeyword: Combinator<Keyword>;
   AtRulePrelude: Combinator<ValueNode | null>;
   ContainerStyleQuery: Combinator<FunctionCall>;
   ContainerQueryInParens: Combinator<ValueNode>;
@@ -3506,18 +3507,41 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
   );
 
   /*
+   * A `<layer-name>` is `<ident> ['.' <ident>]*` (css-cascade-5 §6.1): the dotted
+   * sub-layer spelling is ONE identifier, not a class selector or a post-parse
+   * string. It is glued — `b.c`, never `b . c` — so the dots and idents parse
+   * under `noTrivia`, and it reduces to the same plain `Keyword` every other
+   * generic prelude name takes, matching the `DottedAtRuleKeyword` Less produces
+   * for the same header.
+   */
+  const DottedAtRuleKeyword = node<Keyword>(
+    'DottedAtRuleKeyword',
+    sequence(
+      g.Identifier,
+      oneOrMore(sequence(
+        noTrivia(literal('.')),
+        noTrivia(g.Identifier)
+      ))
+    ),
+    children => keyword(children.map(child => requireToken(child).value).join(''))
+  );
+
+  /*
    * A generic at-rule prelude is a comma-separated `<media-query-list>` that
    * may also be absent, so its clause is `QueryClause` exactly as `QueryPrelude`'s
    * is. It carried a second name for its CALLER, `AtRulePreludeTerm`, and that
-   * is what kept a byte-identical copy alive.
+   * is what kept a byte-identical copy alive. Each clause first admits a dotted
+   * `<layer-name>` (`@layer a, b.c`), which `QueryClause` alone reads as a bare
+   * `b` and abandons at the `.`.
    */
+  const atRulePreludeClause = choice(g.DottedAtRuleKeyword, g.QueryClause);
   const AtRulePrelude = node<ValueNode | null>(
     'AtRulePrelude',
     sequence(
-      optional(g.QueryClause),
+      optional(atRulePreludeClause),
       many(sequence(
         literal(','),
-        g.QueryClause
+        atRulePreludeClause
       ))
     ),
     (children) => {
@@ -5569,6 +5593,7 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
     QueryDashedIdentifier,
     QueryClause,
     QueryPrelude,
+    DottedAtRuleKeyword,
     AtRulePrelude,
     ContainerStyleQuery,
     ContainerQueryInParens,

--- a/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
+++ b/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
@@ -3512,3 +3512,32 @@ describe('keyword boundaries run to full ident-continue', () => {
     expect(() => parse('.a { $extendé .b; }')).toThrow(JessParseError);
   });
 });
+
+describe('@layer dotted sub-layer names', () => {
+  it('reads a dotted name in a statement list as ONE Keyword, not a class selector', () => {
+    expect(parse('@layer a, b.c;')).toMatchObject({
+      rules: [{
+        type: 'AtRuleStatement',
+        name: '@layer',
+        prelude: {
+          type: 'List',
+          sep: ',',
+          value: [{ type: 'Keyword', src: 'a' }, { type: 'Keyword', src: 'b.c' }]
+        }
+      }]
+    });
+    expect(serialize(parse('@layer a, b.c;')).css).toBe('@layer a, b.c;\n');
+  });
+
+  it('reads a dotted block-header name as ONE Keyword', () => {
+    expect(parse('@layer a.b { c { color: red } }')).toMatchObject({
+      rules: [{
+        type: 'AtRuleBlock',
+        name: '@layer',
+        prelude: { type: 'Keyword', src: 'a.b' }
+      }]
+    });
+    expect(serialize(parse('@layer a.b { c { color: red } }')).css)
+      .toBe('@layer a.b {\n  c {\n    color: red;\n  }\n}\n');
+  });
+});

--- a/test/css-superset-corpus.ts
+++ b/test/css-superset-corpus.ts
@@ -156,18 +156,17 @@ export const CSS_CONSTRUCTS: readonly CssConstruct[] = [
   {
     id: '@layer statement with a dotted sub-layer name',
     group: 'at-rule',
-    source: '@layer a, b.c;',
-    brokenIn: ['jess'],
-    defect:
-      'Jess consumes nothing. css-cascade-5 §6.1 spells `<layer-name>` as '
-      + '`<ident> ["." <ident>]*`, so `b.c` is ONE layer name; the Jess prelude '
-      + 'appears to see the class-selector/mixin-call reading of `.c` instead. '
-      + 'The undotted forms above parse in all four.'
+    source: '@layer a, b.c;'
   },
   {
     id: '@layer block',
     group: 'at-rule',
     source: '@layer base { a { color: red } }'
+  },
+  {
+    id: '@layer block with a dotted sub-layer name',
+    group: 'at-rule',
+    source: '@layer a.b { c { color: red } }'
   },
   {
     id: '@layer anonymous block',


### PR DESCRIPTION
## What

Jess rejected dotted `@layer` sub-layer names that CSS, Less and SCSS all accept:

```less
@layer a, b.c;              /* was: parse error */
@layer a.b { c { color: red } }   /* was: parse error */
```

CSS Cascade Level 5 §6.1 defines `<layer-name>` as `<ident> ['.' <ident>]*`, so `b.c` is **one** layer name, not a class selector. Jess's generic at-rule prelude read `b` as a bare query keyword and abandoned the clause at the `.`, so the header never completed and the whole statement/block failed.

## How

The generic at-rule prelude (`AtRulePrelude`) now admits a glued dotted keyword before falling back to a query clause, reducing it to the same plain `Keyword` the undotted forms already produce. Both the statement list and the block header route through that one prelude, so a single arm covers both forms.

```
@layer a, b.c;              ->  @layer a, b.c;
@layer a.b { c { color: red } }  ->  @layer a.b { c { color: red } }
```

Undotted forms (`@layer a;`, `@layer a, b;`) are untouched — the dotted arm only matches when an identifier is immediately followed by a glued `.ident`, and any such input previously failed, so no prior parse changes.

## Tests

- `test/css-superset-corpus.ts`: the dotted statement case graduates from a pinned Jess defect to an all-four-dialect contract, and a dotted block case is added.
- `packages/syntax/jess/jess-parser/test/ast-grammar.test.ts`: positive AST-shape assertions that `b.c` / `a.b` parse to a single `Keyword` (not a class selector) and round-trip through serialization.

## Verification

- jess-parser suite: 527 passed (incl. 2 new AST tests + macro-compiled gate)
- All four dialect CSS-construct corpus suites: 595 passed
- core 3262 · fns 718 · language-service 264 · jess ratchet 1425 (pass set matches baseline exactly)
- `check:macro` (0 interpreter fallbacks) · `check:compose-fused` · `check:reducer-purity` · `check:guardrails` — all green
- `verify:types` 24/24 · ESLint whole grammar file: 0 errors
- Parse benchmark (n=25, w=8) neutral / within noise: jess-ast data 0.473ms → 0.455ms, package-files 0.306ms → 0.307ms (both INCONCLUSIVE)

Grammar and semantics reviews both returned no blocking findings. Non-blocking follow-ups (out of scope for a parity fix): the typed at-rule prelude is duplicated across Jess/Less/SCSS and would collapse when that family is de-duplicated toward a shared layer-name production; and the `<layer-name>` → single `Keyword` representation could be recorded explicitly in the design ledger.
