### PR TITLE
fix(jess): accept @property body with an optional final semicolon

### DIFF
--- a/packages/syntax/jess/jess-parser/src/grammar.ts
+++ b/packages/syntax/jess/jess-parser/src/grammar.ts
@@ -4196,7 +4196,17 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
         literal(':'),
         g.HeaderValue
       )),
-      literal(';')
+
+      /*
+       * `;` SEPARATES descriptors; it never TERMINATES the last one. The final
+       * descriptor before `}` may omit it, exactly as css/less/scss spell every
+       * declaration-list body — the shared `declarationListDeclaration` separator
+       * `choice(literal(';'), peek(literal('}')))`. See DESIGN-DECISIONS P11.
+       */
+      choice(
+        literal(';'),
+        peek(literal('}'))
+      )
     ),
     (children, fields) => {
       const value = children[2];

--- a/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
+++ b/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
@@ -1818,6 +1818,23 @@ describe('Jess AST grammar facts', () => {
     }
   });
 
+  it('accepts an @property body whose last descriptor omits the trailing `;`', () => {
+    const source = '@property --x { syntax: "*"; inherits: true }';
+    const direct = run(jessGrammar.Stylesheet, source, { trivia: jessGrammar.whitespace });
+    expect(direct.ok).toBe(true);
+    expect(direct.unconsumedFrom).toBeNull();
+    expect(parse(source)).toMatchObject({
+      type: 'Stylesheet',
+      rules: [{
+        type: 'AtRuleBlock', name: '@property', prelude: { type: 'Keyword', src: '--x' },
+        rules: [{ type: 'Declaration', name: 'syntax' }, { type: 'Declaration', name: 'inherits' }]
+      }]
+    });
+
+    /* The optional final `;` is a separator, so the two spellings render identically. */
+    expect(serialize(parse(source))).toEqual(serialize(parse('@property --x { syntax: "*"; inherits: true; }')));
+  });
+
   it('keeps static @property descriptor lists and function values typed without admitting Jess values', () => {
     const source = '@property --offset { syntax: "<length>+"; inherits: false; initial-value: 1px 2px; } @property --accent { syntax: "<\\\\63olor>"; inherits: false; initial-value: color-mix(in srgb, rgb(1 2 3), blue); }';
     const root = parse(source);

--- a/test/css-superset-corpus.ts
+++ b/test/css-superset-corpus.ts
@@ -283,12 +283,7 @@ export const CSS_CONSTRUCTS: readonly CssConstruct[] = [
   {
     id: '@property with an unterminated last descriptor',
     group: 'at-rule',
-    source: '@property --x { syntax: "*"; inherits: true }',
-    brokenIn: ['jess'],
-    defect:
-      'Jess requires a trailing `;` on the last descriptor of an `@property` '
-      + 'body. css-syntax-3 §5.4.4 makes the final `;` optional in ANY declaration '
-      + 'list; adding it makes this exact source parse in Jess.'
+    source: '@property --x { syntax: "*"; inherits: true }'
   },
   {
     id: '@page bare',


### PR DESCRIPTION
## What

`@property --x { syntax: "*"; inherits: true }` — an `@property` body whose last
descriptor has no trailing `;` — was a parse error in jess, while css, less, and
scss all accept it. Adding the trailing `;` parsed. This fixes jess to accept the
no-trailing-`;` form.

## Why

`;` separates declarations in a declaration list; it never terminates the last
one. The final declaration in a block may omit it (css-syntax-3 §5.4.4). jess's
`@property` descriptor body was the only place that required it: `PropertyDescriptor`
ended in a mandatory `literal(';')`, and `PropertyAtRule` collects those with
`many(PropertyDescriptor)`, so a last descriptor without `;` fell out of the
`many` and the closing `}` failed to match.

## How

Converge the `@property` descriptor terminator onto the shared declaration-list
separator the css base already uses everywhere — `declarationListDeclaration`'s
`choice(literal(';'), peek(literal('}')))`:

```
-      literal(';')
+      choice(
+        literal(';'),
+        peek(literal('}'))
+      )
```

`peek` is zero-width, so a `;`-terminated descriptor still matches the first
branch and its emitted node is unchanged. `peek(literal('}'))` is a better fit
here than jess's ordinary-declaration `not(literal(','))` separator: an
`@property` body's follow-set is closed (`;` or `}` only), so peeking the brace
still rejects a *missing* separator between two descriptors
(`syntax: "*" inherits: true`), which `not(',')` would wrongly accept.

Recognition only — no serializer change. Input → output for every input that
already parsed is byte-identical; the delta is purely that one previously-rejected
shape now parses.

## Input → output

| input | before | after |
|-------|--------|-------|
| `@property --x { syntax: "*"; inherits: true; }` | parses | parses (identical tree/output) |
| `@property --x { syntax: "*"; inherits: true }` | parse error | parses; renders identically to the `;`-terminated form |
| `@property --x { syntax: "*" inherits: true }` (missing separator) | parse error | parse error (still rejected) |

## Scope

Only the `@property` descriptor body carried a mandatory-`;` terminator. Every
other jess at-rule body (`@font-face`, `@counter-style`, keyframes, and the
generic at-rule block) already routes through the ordinary `Declaration`, whose
separator already makes the final `;` optional — so no other at-rule shares this
defect and the fix stays scoped to `@property`.

## Tests / checks

- New AST-shape test: the no-trailing-`;` `@property` body parses to two
  `Declaration` descriptors and serializes identically to the `;`-terminated form.
- The css-superset construct corpus entry for this form flipped from a pinned
  defect (rejected in jess) to an accepted-in-all-dialects contract.
- jess-parser suite 528/528; packages/core 3262; packages/fns 718;
  language-service 264; packages/jess ratchet exact baseline (1425, 0 failing).
- jess byte-identity oracle byte-identical before/after (148 entries, 0 trees
  moved). `check:macro` / `check:compose-fused` / `check:reducer-purity` /
  `check:guardrails` all green. Parse-bench medians unchanged (within noise).
