### PR TITLE
fix(scss): accept var() empty fallback `var(--x,)`

### DIFF
--- a/packages/syntax/scss/scss-parser/src/grammar.ts
+++ b/packages/syntax/scss/scss-parser/src/grammar.ts
@@ -858,6 +858,55 @@ const scssFactory = (g: ScssInputRules) => {
   );
 
   /*
+   * `var(--x,)` — a trailing comma with nothing after it — is `var()` with an
+   * EMPTY fallback: css-variables-1 §3 spells the fallback `<declaration-value>?`,
+   * so the empty value is well-formed and means "the empty value". Every other
+   * dialect accepts it; the generic `Call` argument list has no empty-argument
+   * slot, so `var(` alone is routed to a var-specific tail that permits it. The
+   * empty fallback lowers to `any('')`, the same node css records for it, so the
+   * built call is `var(--x, «empty»)`.
+   */
+  const VarEmptyFallback = node<ScssArgumentPair>(
+    'VarEmptyFallback',
+    noTrivia(sequence(
+      optional(valueTrivia),
+      literal(','),
+      optional(valueTrivia)
+    )),
+    (children) => {
+      const separator = children.map(child => requireToken(child).value).join('');
+      if (!separator.includes(',')) {
+        throw new TypeError('VarEmptyFallback lost its comma.');
+      }
+      return { separator, value: callArg(any('')) };
+    }
+  );
+
+  /*
+   * A var-specific tail: the SAME argument grammar and reducer as `Call`, plus a
+   * single optional trailing empty fallback. Absent that trailing comma the
+   * sequence is byte-for-byte `Call`, so `var(--x)` / `var(--x, red)` /
+   * `var(--x, var(--y, red))` build the identical `FunctionCall` they always
+   * have. The trailing arm is reachable ONLY from the `var(` dispatch key, so a
+   * generic `foo(a,)` stays the parse error css also rejects.
+   */
+  const VarCall = node<FunctionCall | Reference | IfValue>(
+    'Call',
+    sequence(
+      routed(),
+      optional(valueTrivia),
+      optional(sequence(
+        g.CallArgument,
+        many(g.ArgumentPair)
+      )),
+      optional(VarEmptyFallback),
+      optional(valueTrivia),
+      literal(')')
+    ),
+    children => reduceScssCall(requireToken(children[0]).value.slice(0, -1), children, 0)
+  );
+
+  /*
    * A namespaced CALL keeps its authored callee path in the `FunctionCall` name
    * (`color.mix`). That is the lossless store: the parser cannot know whether a
    * qualifier names a built-in `sass:` module or a `@use`d file, and splitting
@@ -868,6 +917,7 @@ const scssFactory = (g: ScssInputRules) => {
   const IdentifierOrFunction = dispatch(
     identOrFunction,
     caseInsensitive('url(', UrlFunction),
+    caseInsensitive('var(', VarCall),
     when(endsWith('('), Call),
     when(matches(/\.\$/), NamespacedVariable),
     otherwise(KeywordOrInterpolatedValue)

--- a/packages/syntax/scss/scss-parser/test/css-superset-constructs.test.ts
+++ b/packages/syntax/scss/scss-parser/test/css-superset-constructs.test.ts
@@ -17,6 +17,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { parseScssCst } from '@jesscss/scss-parser/cst';
+import { parse } from '@jesscss/scss-parser';
 import { acceptedIn, pinnedDefectsIn, CSS_CONSTRUCTS } from '../../../../../test/css-superset-corpus.js';
 
 const DIALECT = 'scss';
@@ -66,4 +67,21 @@ describe('CSS construct space — SCSS grammar', () => {
       ).toBe(false);
     }
   );
+
+  /*
+   * `var()`'s empty fallback (css-variables-1 §3 `<declaration-value>?`) builds a
+   * `var(--x, «empty»)` call whose fallback is the empty `Any` node — the same
+   * node css records for it — and leaves the non-empty fallback path untouched.
+   */
+  it('builds var(--x,) as a var call with an empty Any fallback', () => {
+    const value = parse('a { color: var(--x,) }').rules[0].rules[0].value;
+    expect(value).toMatchObject({
+      type: 'FunctionCall',
+      name: 'var',
+      args: [
+        { value: { type: 'Keyword', src: '--x' } },
+        { value: { type: 'Any', src: '' } }
+      ]
+    });
+  });
 });

--- a/test/css-superset-corpus.ts
+++ b/test/css-superset-corpus.ts
@@ -539,12 +539,7 @@ export const CSS_CONSTRUCTS: readonly CssConstruct[] = [
   {
     id: 'var() with an empty fallback',
     group: 'value',
-    source: 'a { color: var(--x,) }',
-    brokenIn: ['scss'],
-    defect:
-      'css-variables-1 §3 makes the fallback `<declaration-value>?`, so the '
-      + 'empty fallback is well-formed and means "the empty value". SCSS alone '
-      + 'rejects it, with or without a space before the `)`.'
+    source: 'a { color: var(--x,) }'
   },
   {
     id: 'calc() nested in calc()',


### PR DESCRIPTION
## What

SCSS rejected `a { color: var(--x,) }` — `var()` with an **empty fallback** — as a parse error, while CSS, Less and Jess all accept it.

```scss
a { color: var(--x,) }     /* before: parse error   after: parsed */
a { color: var(--x , ) }   /* before: parse error   after: parsed */
```

`css-variables-1` §3 spells `var()`'s fallback `<declaration-value>?`, so an empty fallback is well-formed and means "the empty value".

## Why it happened

SCSS routed every `var()` through the generic function-call production, whose argument list has no empty-argument slot, so a trailing comma before `)` had nothing to match and the parse failed.

## Fix

Route `var(` to a var-specific tail (the same way `url(` is already dispatched): the **same** argument grammar and reducer as a generic call, plus one `optional` trailing empty fallback that lowers to the empty `Any` node the other dialects already record.

- Non-empty fallback path is unchanged and byte-identical: `var(--x)`, `var(--x, red)`, `var(--x, var(--y, red))` build the identical `FunctionCall` they always have (the trailing arm matches nothing when absent).
- Scoped to `var(`: the empty-fallback slot is reachable only from the `var(` dispatch key, so a generic `foo(a,)` stays the parse error CSS also rejects.
- `var(--x,)` now builds `var(--x, «empty»)` where the fallback is `{ type: 'Any', src: '' }`, matching CSS's own representation.

## Verification

- **scss-parser**: 627 passed (incl. the flipped construct case and a new AST-shape assertion for `var(--x,)`).
- **SCSS byte-identity oracle**: before vs after over 2524 corpus entries — IDENTICAL (ast + cst aggregate hashes unchanged); the new accept is the only delta.
- **core** 3262 passed · **fns** 718 passed · **language-service** 264 passed · **jess** ratchet 1427, 0 failing (exact baseline match).
- `check:macro` / `check:compose-fused` / `check:reducer-purity` / `check:guardrails` — all green.
- **Parse perf** (sass-spec, 2404 files, medians): ast 31.68→31.60 ms, cst 38.28→37.74 ms — flat (within noise).
- Whole-file `eslint` on the grammar — 0 errors.