### PR TITLE
fix(less): accept functional media-query prelude as general-enclosed

### DIFF
--- a/docs/state/PINNED-DEFECTS-AUDIT.md
+++ b/docs/state/PINNED-DEFECTS-AUDIT.md
@@ -108,7 +108,7 @@ Pinned through `<dialect>-parser/test/css-superset-constructs.test.ts:58`
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | D11 | Unbalanced `]` inside a custom property | css:183, less:146, scss:145, jess:156 | all four | `a{--x: foo(] bar}` → parse error → declaration keeps the token stream (css-syntax-3 §5.4.8: stray `]` is a consumed, non-fatal parse error) | HIGH-R | holds | P2 (custom-property values are a permissive arbitrary token stream) — this input violates the ruled shape | the custom-property value production balances brackets; make a stray closer a consumed token |
 | D12 | Attribute-flag spacing divergence | less:110 (Less keeps `[href="x" i]`); css side pinned as normal expectation in css `discovered-constructs.test.ts`; `css-parser/test/byte-identity.divergences.json` "open" | less vs css/scss/jess | `a[href="x" i]` → Less emits `[href="x" i]`, css/scss/jess emit `[href="x"i]` → ONE spelling in all four (which one is the ruling) | MEDIUM | holds | the json entry records it as needing an owner ruling; unruled | owner picks: byte-identity (keep authored space) or canonicalise; then align the other side |
-| D13 | Functional media-query prelude | less:182 | less | `@media foo(bar) {…}` → parse error → accepted (css, scss, jess accept) | HIGH-R | holds | unowned | Less media-query prelude override lacks the `<general-enclosed>` function form the css base has |
+| D13 | Functional media-query prelude | less:182 | less | `@media foo(bar) {…}` → parse error → accepted (css, scss, jess accept) | HIGH-R | FIXED (pin flipped to acceptance) | unowned (spec-mandated; SEMANTIC-INVARIANTS §4 one-way rule) | DONE — Less `QueryTerm` gained a `<general-enclosed>` function arm reusing the existing `Enclosed` node (`peek(EnclosedFunctionName)`-gated). less now byte-matches css/jess (`@media foo(bar){…}`). Follow-up (separate, scss-only): scss renders `@media foo (bar){…}` — it reads `foo(bar)` as keyword + paren block, not a general-enclosed function |
 | D14 | Bare parenthesised component value | jess:55 | jess | `a { b: (c) }`, `( c )`, `(1 + 2)` → parse error → accepted (css-syntax-3 §5.4.7 simple block); css/less/scss accept the tight form | HIGH-R | holds | P18 OPEN (where the CSS-superset guarantee stops in `.jess`) | needs the P18 ruling; test comment says `$(…)` does not license rejecting the plain paren block |
 | D15 | Less/Jess reject Sass module forms | less:206 (`ns.fn()`, `ns.$var`, `map.get($m,k)`, `color.mix(red,blue)`, `ns.$v: value;`), jess:249 (`ns.fn()`, `ns.$var`, `f($x: 1)`, `f($x...)`) | less, jess | Sass-only syntax → parse error → parse error is "arguably right"; pinned as leakage guards for whatever admits them in scss | LOW | holds | unowned (deliberate guard, not a defect claim) | none; flip only if a ruling admits these in Less/Jess |
 | D16 | SCSS star-hack property name lost | scss:92 | scss | `a{*color:red}` → `Declaration{name:"*", value:red}` (`color` discarded, parse succeeds) → `name:"*color"` as Less produces | HIGH | holds | unowned | scss property-name production takes `*` as the whole name; extend it to `*` + ident like Less |
@@ -155,9 +155,9 @@ Pinned through `<dialect>-parser/test/css-superset-constructs.test.ts:58`
 
 - D12 and D37 are one defect recorded in two places; counted once.
 - HIGH (3): D16, D19 (jess half), D25.
-- HIGH-R (21): D1–D11, D13, D14, D18, D20, D21, D23, D24, D24a, D26, D27.
+- HIGH-R (20 open; D13 FIXED): D1–D11, D14, D18, D20, D21, D23, D24, D24a, D26, D27.
   D19's scss half is folded into D19.
 - MEDIUM (8): D12, D22, D28, D29, D30, D31, D35, D36.
 - LOW (6): D15, D17, D32, D33, D34, D38 (D38 is by design).
-- Unowned (22): D1, D2, D3, D4, D6, D7, D8, D10, D13, D15, D16, D17, D18,
+- Unowned (21 open; D13 FIXED): D1, D2, D3, D4, D6, D7, D8, D10, D15, D16, D17, D18,
   D20, D22, D24, D25, D28, D29, D31, D32, D34.

--- a/packages/syntax/css/css-parser/test/discovered-constructs.test.ts
+++ b/packages/syntax/css/css-parser/test/discovered-constructs.test.ts
@@ -175,7 +175,8 @@ describe('CSS constructs discovered outside the parser suites', () => {
     /*
      * These parsed while silently losing the `selector` / `foo` name off the
      * prelude — a wrong tree from a successful parse, the hardest kind to
-     * notice. Less still rejects the media form; that is pinned in its suite.
+     * notice. The media form is now accepted as `<general-enclosed>` in every
+     * dialect (Less's acceptance is pinned in its own discovered-constructs suite).
      */
     expect(() => parse(source)).not.toThrow();
   });

--- a/packages/syntax/less/less-parser/src/grammar.ts
+++ b/packages/syntax/less/less-parser/src/grammar.ts
@@ -3307,6 +3307,13 @@ const lessGrammarFactory = (g: LessInputRules & SharedSyntax) => {
       attempt(g.MixinReference),
       g.QueryFeature,
       g.VariableReference,
+      // `<general-enclosed>` function form (media-queries-5 §2.1/§3.1:
+      // `<function-token> <any-value> )`), e.g. `@media foo(bar)`. This is the
+      // SAME general-enclosed node `@supports` already reuses; the `peek`
+      // restricts entry to the function arm so a bare `( … )` group still falls
+      // through to `QueryFeature`, matching the CSS base's term-level shape
+      // (which admits the function form but no bare-paren general-enclosed).
+      sequence(peek(g.EnclosedFunctionName), g.Enclosed),
       g.QueryNonOnlyKeyword
     ),
     children => requireValueNode(children[0])

--- a/packages/syntax/less/less-parser/test/discovered-constructs.test.ts
+++ b/packages/syntax/less/less-parser/test/discovered-constructs.test.ts
@@ -179,14 +179,29 @@ describe('Less constructs discovered outside the parser suites', () => {
     expect(clean.unconsumedFrom).toBeNull();
   });
 
-  it('PINNED DEFECT — rejects a functional media query prelude', () => {
+  it('accepts a functional media query prelude as general-enclosed', () => {
     /*
-     * `@media foo(bar)` is an unknown-but-well-formed media feature spelling;
-     * CSS, SCSS and Jess all accept it and Less alone rejects it. Valid CSS
-     * is valid in every dialect, one way, so a Less-only rejection of a CSS
-     * prelude shape is a gap.
+     * `@media foo(bar)` is the `<general-enclosed>` function form
+     * (media-queries-5 §2.1/§3.1: `<function-token> <any-value> )`); CSS, SCSS
+     * and Jess all accept it and Less used to reject it alone. Valid CSS is
+     * valid in every dialect, one way, so the Less media-query prelude reuses
+     * the SAME general-enclosed node `@supports` already carries — the payload
+     * is opaque, so any-value contents parse rather than being read as a typed
+     * Less argument list.
      */
-    expect(() => parse('@media foo(bar) { a { b: c } }')).toThrow();
+    const media = parse('@media foo(bar) { a { b: c } }').rules[0];
+    const prelude = media?.type === 'AtRuleBlock' ? media.prelude : null;
+
+    expect(prelude).toMatchObject({
+      type: 'FunctionCall',
+      name: 'foo',
+      args: [
+        { name: undefined, spread: false, value: { type: 'Interpolation' } }
+      ]
+    });
+
+    // The general-enclosed payload is an opaque any-value, not a typed arg list.
+    expect(() => parse('@media foo(a b !weird$) { a { b: c } }')).not.toThrow();
   });
 
   it.each([


### PR DESCRIPTION
## What

Less alone rejected `@media foo(bar) {…}` with a parse error, while CSS, SCSS and Jess all accept it.

```less
@media foo(bar) { a { b: c } }   /* before: parse error (Less only) */
```

`foo(bar)` in a media-query prelude is the CSS `<general-enclosed>` function form (media-queries-5 §2.1/§3.1: `<function-token> <any-value> )`) — an unknown-but-well-formed feature spelling that must be accepted opaquely, not rejected. The CSS base's media-query prelude admits this form; Less's `QueryTerm` override had dropped it.

## Change

One additive alternative on Less's `QueryTerm` (`packages/syntax/less/less-parser/src/grammar.ts`):

```ts
sequence(peek(g.EnclosedFunctionName), g.Enclosed),
```

It reuses the **existing** general-enclosed node `Enclosed` — the same node `@supports` already carries — rather than introducing a new rule. The `peek(EnclosedFunctionName)` gate restricts entry to the function form so a bare `( … )` group still falls through to `QueryFeature`, exactly matching the CSS base's term-level shape (function form yes, bare-paren general-enclosed no).

## Input → output

| Input | Before | After |
| --- | --- | --- |
| `@media foo(bar) { a { b: c } }` | parse error | `@media foo(bar) { … }` |
| `@media foo(a b !weird$) { … }` | parse error | accepted (opaque any-value payload) |
| `@media (foo bar) { … }` | reject | reject (unchanged) |
| `@media only { … }` | reject | reject (unchanged) |
| `@media screen and foo(bar) { … }` | parse error | accepted |

Less now renders `@media foo(bar){…}` **byte-identical** to CSS and Jess (verified: css/less/jess all emit `@media foo(bar) {…}`).

## Verification

- **less-parser suite:** 742 pass (17 files).
- **Byte-identity oracle (controlled A/B, fresh pre-fix baseline vs post-fix, same build):** AST surface **identical** (aggregate unchanged, threw 118→118, 0/670 entries moved). CST surface: 4/670 moved — all malformed `@media` error-recovery fixtures (`@media`, `@media (missing: bracket {…`, `@media { color: red }`, `@media {}`), each still a parse error (accept/reject unchanged); only the recovery-trace digest shifts because a new alternative is *attempted* during recovery.
- **Parse perf (benchmark.less, less-parser, 60-round medians):** before ~28.3–28.6 ms / after ~27.3–29.0 ms — within run-to-run noise; the new arm is a fast-failing `peek` lookahead only on media query terms.
- **core** 3262 pass · **fns** 718 pass · **language-service** 264 pass · **jess `test:ratchet`** 1427, exact-match baseline holds (0 failing).
- `check:macro`, `check:compose-fused`, `check:reducer-purity`, `check:guardrails` all green.
- `eslint` on the whole `grammar.ts`: 0 errors.

## Reviews

- **grammar-reviewer:** conforms, no blocking findings. The `peek`-gated reuse of `Enclosed` is the correct idiom (no duplicated reducer, no new const name); placement before `QueryNonOnlyKeyword` is load-bearing and does not over-broaden vs the CSS base.
- **semantics-reviewer:** no blocking findings; conforms on invariants 1–3, 5–7. It asked to confirm invariant 4 (valid CSS → byte-identical output across dialects). Verified: Less now matches CSS and Jess byte-for-byte. SCSS still emits `@media foo (bar){…}` (a stray space — it reads `foo(bar)` as keyword + paren block, not a general-enclosed function). That SCSS divergence **predates this change** and is out of scope here; it is recorded as a follow-up on the D13 row.

Also included: the D13 row in `docs/state/PINNED-DEFECTS-AUDIT.md` is marked fixed (with the SCSS follow-up noted), and a stale comment in the CSS discovered-constructs suite is corrected.
