### PR TITLE
docs: refresh pinned-defect audit, grammar-dedup log, and core handoff

### DIFF
--- a/docs/architecture/core/HANDOFF.md
+++ b/docs/architecture/core/HANDOFF.md
@@ -258,6 +258,43 @@ slices. No slice merges as part of this lane.
   performance sanity. Deterministic path/allocation/scan counts enforce the compiler
   architecture, and code deletion alone is not described as a speedup.
 
+## SESSION HANDOFF — 2026-09-04 (grammar / pinned-defects / Less-gaps driver)
+
+Ran the grammar-cleanup, pinned-defect, and Less-gap lanes while the V19
+one-evaluator fold (ACTIVE PLAN above) landed slices 1-4 in parallel
+(`refactor/one-evaluator-lookup-leaf`, PRs #134-136). No conflict: every grammar
+fix here is parser-side only; the fold owns `serialize.ts`.
+
+**Landed to `dev` this session** (each its own PR, byte-identity + ratchet-exact +
+two blocking reviewers): Percentage->Dimension convergence #137; `@container`
+gaps #138; jess pseudo leading-combinator #140; jess comment->compound #142; SCSS
+star-hack #143; jess paren block #144; ledger rulings #139/#145; gap fixes
+#146-#152 (D8/D1/D5/D7/D13/D6) and the Less comment-fold pair #141+#148. Also
+earlier this session: fork sync, Jess 2.0.0-alpha.16 + Less 5.0.0-alpha.3 publish
+(browser bundle on CDN), less-preview restyle + version-gated options, the
+release-preflight dedupe #130/#131 (381s->90s), and the pinned-defect audit #128
+(`docs/state/PINNED-DEFECTS-AUDIT.md`). Full defect->PR map + rulings are in that
+audit's "Update — 2026-09-04" section and `GRAMMAR-DEDUP-LOG.md`'s 2026-09-04 entry.
+
+**BLOCKED ON THE FOLD — do not re-dispatch until slice 5 lands:** the SCSS
+block-comment trivia family (audit D9/D17/D21/D23/D27 + the SCSS half of D19,
+ledger G26/G29). Measured 2026-09-03: declaring `blockComment` in the scss trivia
+table alone DROPS block comments, because SCSS tags ~4 statement `withSourceSpan`
+sites vs Less's ~41, so G28's block-interior replay has no anchor. It needs (a) an
+SCSS statement-source-span lane and (b) a block-interior replay that lives in the
+`serialize.ts` trivia code THIS fold is consolidating (slice 1 = "body trivia
+ownership into the one evaluator"). Sequence: fold slice 5 -> SCSS statement
+spans -> declare `blockComment`. See
+`memory:scss-trivia-family-blocked-on-statement-spans-and-fold`.
+
+**Owner decisions still pending** (surfaced, not decided): D22 (jess escaped-interp
+`~"x$(1+1)y"` AST-shape model change), D24 (scss `&`-as-value node model). Owned/
+spec-clear but unscheduled: D24a (scss `@-` namespace, G30), D18 (scss Sass module
+forms), D11 (unbalanced `]` in custom props, P2, all four), D10 (top-level CDO/CDC,
+near-zero value). Cleanups: scss `@media foo(bar)` stray-space render (chip), and
+two grammar dedups (four `<query-in-parens>` forks; typed at-rule prelude x3).
+
+
 ## SESSION HANDOFF — 2026-08-17, jess dev `6d7fbe82d` (CURRENT — read first)
 
 **CURRENT FOCUS (owner, 2026-08-17): strengthen the Less compilation story so we can

--- a/docs/state/GRAMMAR-DEDUP-LOG.md
+++ b/docs/state/GRAMMAR-DEDUP-LOG.md
@@ -1177,3 +1177,27 @@ now quantified — a big multi-week effort, not a switch.
   all green. Tracker rows Less #3, jess `Dimension`+`Percentage`, scss `Percentage`
   flipped ☑. The committed less/scss oracle baselines were already stale pre-edit
   (drift-detectors, not CI-gated) and are NOT rebaselined here.
+- 2026-09-04 — **Pinned-defect / Less-gap batch LANDED** (all merged to `dev`,
+  each its own PR with byte-identity oracle + ratchet-exact + both reviewers):
+  `@container` prelude gaps #138 (D2/D3/D4); jess pseudo leading-combinator #140
+  (D20, converged to the base — all five selector pseudos, not `:has()`-special);
+  jess comment→compound #142 (D19, G26); SCSS star-hack name #143 (D16, G31);
+  jess paren block #144 (D14, P18(a)); jess `url()` escapes #146 (D8); jess
+  `@layer` dotted names #147 (D1); Less comment-fold pair #141+#148 (D25, G32/G34
+  — Less-LOCAL `Dimension` override widening the hyphen lookahead, shared
+  `parser-shared` terminal UNTOUCHED so CSS/SCSS/.jess keep `px-`); jess
+  `@property` optional final `;` #149 (D5, P11); scss `var()` empty fallback #150
+  (D7); less `@media foo(bar)` #151 (D13, reused `Enclosed`); jess `@page`
+  pseudo-page #152 (D6). Rulings recorded in DESIGN-DECISIONS: G26, P18(a), G31
+  (corrected: css REJECTS the star hack), G32/G34, G33 (spaced value slash
+  by-design), P29 status note. Process: added a whole-file `npx eslint <grammar>`
+  step to every grammar-agent brief (CI lints the whole file; the pre-commit hook
+  only checks changed lines — a stray `lines-around-comment` sank #140 once); and
+  the `*-macro-compiled` Vite-server test flakes under CI load (rerun-don't-debug,
+  see `memory:flake-triage-shared-corpus-and-process-isolation`). Still parked:
+  the SCSS block-comment trivia family (D9/D17/D21/D23/D27 + D19 scss half) is
+  BLOCKED on SCSS statement source-spans + a block-interior replay in the
+  `serialize.ts` trivia code the one-evaluator fold is consolidating — do not
+  re-dispatch until that fold's slice 5 lands. Two grammar dedups noted for later
+  (the four `<query-in-parens>` forks vs scss's unified one; the typed at-rule
+  prelude duplicated across jess/less/scss).

--- a/docs/state/PINNED-DEFECTS-AUDIT.md
+++ b/docs/state/PINNED-DEFECTS-AUDIT.md
@@ -61,6 +61,52 @@ plain CSS — `:has(> .b)` (D20), `@page :first` (D6), `url(a\ b.png)` (D8),
 `@layer a, b.c` (D1) — each is a stylesheet that compiles in css/less/scss
 and fails in `.jess`.
 
+## Update — 2026-09-04 (fixes landed since the snapshot)
+
+The body below is the 2026-09-03 snapshot at `a0b1e66ba` and is left as-is.
+Since then the following defects were fixed and their pins flipped to
+acceptance (each its own merged PR against `dev`):
+
+| Id | Fix | PR |
+| --- | --- | --- |
+| D1 | jess `@layer a, b.c` dotted sub-layer names | #147 |
+| D2/D3/D4 | `@container` parenthesised condition group + `style()` query | #138 |
+| D5 | jess `@property` optional final `;` (P11) | #149 |
+| D6 | jess `@page :first` / `wide:left` pseudo-page | #152 |
+| D7 | scss `var(--x,)` empty fallback | #150 |
+| D8 | jess `url(a\ b.png)` escapes | #146 |
+| D13 | less `@media foo(bar)` general-enclosed prelude | #151 |
+| D14 | jess accepts a plain paren block `(c)` (P18(a)) | #144 |
+| D16 | scss keeps the full `*color` star-hack name (G31) | #143 |
+| D19 | jess `a/*c*/.b` is the compound `a.b` (G26); jess half only | #142 |
+| D20 | jess selector pseudos accept a leading combinator (`:has(> .b)`) | #140 |
+| D25 | Less folds a comment-padded operator to `-1px` (G32 + G34, both comment sides) | #141, #148 |
+| D36 | value slash is a spaced separator — settled by-design, no code (G33) | #139 |
+
+Owner rulings recorded (PR #139, corrected #145): **G26** (comment never splits
+a compound selector), **P18(a)** (a plain paren block parses in `.jess`),
+**G31** (SCSS/Less recover the star-hack name; **css rejects it** — do not
+converge css), **G32/G34** (Less parses a comment-split subtraction as an
+operation; CSS/SCSS/.jess keep the two-token list — measured against lessc 4.6.3
+and dart-sass 1.62.1), **G33** (spaced value slash by design).
+
+**Still open / parked:**
+- SCSS block-comment trivia family (D9, D17, D21, D23, D27) and the SCSS half of
+  D19 — blocked on an SCSS statement-source-span lane + a block-interior replay
+  that lives in the `serialize.ts` trivia code the one-evaluator fold is
+  consolidating. Do not re-dispatch until the fold's slice 5 lands.
+- Value-ladder `noTrivia` pads (D26-scss, D27, D21 `@forward … with(…)`) — the
+  separate G25 sum-pad change, not the trivia table.
+- Need an owner model decision: D22 (jess `~"x$(1+1)y"` escaped-interp AST shape),
+  D24 (scss `&` as a value node).
+- Owned/spec-clear, not yet scheduled: D24a (scss `@-` namespace, G30),
+  D18 (scss Sass module `ns.$v:` / spread), D11 (unbalanced `]` in custom
+  properties, P2, all four), D10 (top-level CDO/CDC, all four — near-zero value).
+- Cleanups: the scss `@media foo(bar)` stray-space render divergence (a chip),
+  and two grammar dedups (the four dialects' separate `<query-in-parens>`; the
+  typed at-rule prelude duplicated across jess/less/scss).
+
+
 ## Reporter noise
 
 The strings scroll by because the root `vitest.config.ts:285` sets


### PR DESCRIPTION
Tracking-doc refresh after the 2026-09-04 grammar / pinned-defect / Less-gap batch (PRs #137-152). Docs only.

- **PINNED-DEFECTS-AUDIT.md** — an `Update — 2026-09-04` section maps each fixed defect to its PR (D1/D2/D3/D4/D5/D6/D7/D8/D13/D14/D16/D19/D20/D25/D36), records the owner rulings (G26, P18(a), G31, G32/G34, G33), and lists what stays parked (the SCSS block-comment trivia family behind the fold) or needs an owner model decision (D22, D24). The 2026-09-03 snapshot body is left intact.
- **GRAMMAR-DEDUP-LOG.md** — a dated batch entry with the same PR map and the two process notes (whole-file eslint step; macro-compile flake rerun rule).
- **HANDOFF.md** — a `SESSION HANDOFF — 2026-09-04` section: what landed, the fold-blocked SCSS trivia family with the measured reason and correct sequence, and the pending owner decisions / cleanups.