### PR TITLE
fix(scss): render a functional media-query prelude as general-enclosed

### DIFF
--- a/packages/syntax/scss/scss-parser/src/grammar.ts
+++ b/packages/syntax/scss/scss-parser/src/grammar.ts
@@ -3167,6 +3167,19 @@ const scssFactory = (g: ScssInputRules) => {
     'QueryClause',
     choice(
       QueryOnlyClause,
+
+      /*
+       * A leading `<general-enclosed>` function term — media-queries-5 §2.1/§3.1
+       * (`<function-token> <any-value> )`), e.g. `@media foo(bar)`. This reuses
+       * the SAME general-enclosed node `QueryInParens` already carries; the
+       * arm only has to move earlier. Without it the media-type arm below reads
+       * `foo` as a keyword and `(bar)` as a separate feature, rendering
+       * `foo (bar)` with a stray space while css/less/jess render `foo(bar)`.
+       * `QueryFunction` opens on `QueryFunctionName`, whose `(?=\()` lookahead
+       * matches only a name glued to `(`, so a bare `( … )` group still falls
+       * through to the media-type / QueryCondition arms.
+       */
+      g.QueryFunction,
       sequence(
         QueryNonOnlyKeyword,
         optional(g.QueryAndOr),

--- a/packages/syntax/scss/scss-parser/test/discovered-constructs.test.ts
+++ b/packages/syntax/scss/scss-parser/test/discovered-constructs.test.ts
@@ -19,6 +19,20 @@
 import { describe, expect, it } from 'vitest';
 import { parse } from '@jesscss/scss-parser';
 import { parseScssCst } from '@jesscss/scss-parser/cst';
+import { serialize as serializeMaybeAsync, type SerializeResult } from '../../../../core/src/ast/serialize.js';
+
+/*
+ * These fixtures are all-sync, so `serialize` never lifts onto its async branch;
+ * asserting that lets a case read `.css` directly and fails loudly rather than
+ * comparing against a pending Promise.
+ */
+function serialize(...args: Parameters<typeof serializeMaybeAsync>): SerializeResult {
+  const result = serializeMaybeAsync(...args);
+  if (result instanceof Promise) {
+    throw new TypeError('This SCSS test expects a synchronous serialize result.');
+  }
+  return result;
+}
 
 /*
  * Narrowed by predicate rather than by assertion: the dialect error class is
@@ -150,6 +164,41 @@ describe('SCSS constructs discovered outside the parser suites', () => {
 
   it('accepts an A+B microsyntax with no spaces around the sign', () => {
     expect(() => parse('a:nth-child(2n+1){c:d}')).not.toThrow();
+  });
+
+  it('accepts a leading functional media-query term as general-enclosed', () => {
+    /*
+     * `@media foo(bar)` is the `<general-enclosed>` function form
+     * (media-queries-5 §2.1/§3.1: `<function-token> <any-value> )`); css, less
+     * and jess render it `@media foo(bar)`. SCSS used to read the leading
+     * `foo` as a media-type keyword and `(bar)` as a separate feature, emitting
+     * `foo (bar)` with a stray space — a "valid CSS, valid in every dialect"
+     * byte-identity divergence. It now reuses the SAME `QueryFunction`
+     * general-enclosed node the shared query grammar already carries.
+     */
+    const sheet = parse('@media foo(bar) { a { b: c } }');
+    const media = sheet.rules[0];
+    const prelude = media?.type === 'AtRuleBlock' ? media.prelude : null;
+
+    expect(prelude).toMatchObject({
+      type: 'FunctionCall',
+      name: 'foo',
+      args: [
+        { spread: false, value: { type: 'Any', src: 'bar' } }
+      ]
+    });
+
+    /*
+     * The emitted bytes, not just the tree: `foo(bar)` with no stray space,
+     * byte-identical to what css/less/jess render for the same source.
+     */
+    expect(serialize(sheet).css).toBe('@media foo(bar) {\n  a {\n    b: c;\n  }\n}\n');
+
+    // The general-enclosed payload is an opaque any-value, not a typed arg list.
+    expect(() => parse('@media foo(a b !weird$) { a { b: c } }')).not.toThrow();
+
+    // A bare `( … )` group still falls through to the feature/condition arms.
+    expect(() => parse('@media (min-width: 10px) { a { b: c } }')).not.toThrow();
   });
 
   it.each([


### PR DESCRIPTION
## Summary

`@media foo(bar) {…}` is the CSS `<general-enclosed>` function form (media-queries-5 §2.1/§3.1: `<function-token> <any-value> )`). SCSS alone serialized it as `@media foo (bar) {…}` — with a stray space — because the media-query clause read the leading `foo` as a media-type keyword and `(bar)` as a separate feature. CSS, Less (since #151) and Jess all render `foo(bar)`. Valid CSS is valid in every dialect, one way, so this was a byte-identity divergence with SCSS as the outlier.

## Fix

One additive arm on `QueryClause`, reusing the `QueryFunction` general-enclosed node the shared query grammar already carries (it is already wired into `QueryInParens` for the `screen and foo(bar)` position — only the leading-term position was missing it):

```ts
choice(
  QueryOnlyClause,
  g.QueryFunction,               // ← new: leading `<general-enclosed>` term
  sequence(QueryNonOnlyKeyword, optional(g.QueryAndOr), g.QueryInParens),
  g.QueryCondition,
  QueryNonOnlyKeyword
)
```

`QueryFunction` opens on `QueryFunctionName`, whose regex ends `(?=\()` — it matches a name only when it is glued to `(`. So the arm needs no explicit peek: a bare `( … )` group has no leading glued name and still falls through to the media-type / condition / feature arms. Placing it before the media-type arm means `foo(bar)` is recognized whole instead of split into keyword + feature.

SCSS now renders `@media foo(bar){…}` byte-identically to the other three dialects. `@container foo(bar)` and `@container style(--x:1)` (which share the same clause and previously also emitted the stray space) are fixed by the same change.

## Verification

- Cross-dialect render, byte-identical after the fix: `@media foo(bar)`, `@media screen and foo(bar)`, `@media (min-width: 10px)`, `@media only screen`, `@media screen, print`, `@media foo(a b !weird$)`, `@container foo(bar)`.
- scss-parser suite: 628 pass (adds a red→green `discovered-constructs` test with a negative control).
- packages/core (3262), fns (718), language-service (264): pass. `jess` `test:ratchet`: pass set matches baseline exactly.
- `check:macro`, `check:reducer-purity`, `check:compose-fused`, `check:guardrails`: pass. Whole-file eslint on the grammar: clean.
- Parse-perf A/B (sass-spec corpus, 40 samples ×2): neutral (within ±2%, overlapping ranges).

## Notes

The general-enclosed payload stays an opaque any-value, so `@media foo(a b !weird$)` parses rather than being read as a typed argument list. The value-first / comma-separated non-`<mf-value>` feature forms are unchanged and still report the typed parse error.
