### PR TITLE
fix(jess): accept @container (not (…)) query-in-parens

### DIFF
--- a/packages/syntax/css/css-parser/test/conditional-at-rule-value.test.ts
+++ b/packages/syntax/css/css-parser/test/conditional-at-rule-value.test.ts
@@ -190,7 +190,9 @@ const COMPOSITION: Array<[string, string, object]> = [
   ['a list whose first query is an and chain', '@media screen and (hover), print { a { color: red; } }',
     list({ type: 'Sequence', parts: [kw('screen'), kw('and'), paren(kw('hover'))] }, kw('print'))],
   ['a comma-separated @container query list', '@container (width > 1px), (height > 1px) { a { color: red; } }',
-    list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))]
+    list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))],
+  ['a negated @container query-in-parens', '@container (not (width > 1px)) { a { color: red; } }',
+    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })]
 ];
 
 /**

--- a/packages/syntax/jess/jess-parser/src/grammar.ts
+++ b/packages/syntax/jess/jess-parser/src/grammar.ts
@@ -3674,14 +3674,29 @@ const jessFactory = (g: JessRules & SharedSyntax) => {
     ),
     children => requireValueNode(children[0])
   );
+
+  /*
+   * One `<container-query>` (css-contain-3 §3): `not <query-in-parens>` or an
+   * atom followed by an `and`/`or` chain. The leading-`not` arm is tried first
+   * so a `( not (width > 1px) )` group negates its inner condition — the same
+   * shape css's `ContainerQueryCondition` produces, `Sequence[not, Block(…)]`.
+   * The reducer already lowers the `not`/`and`/`or` tokens to keywords, so both
+   * arms share it.
+   */
   const ContainerQueryClause = node<ValueNode>(
     'ContainerQueryClause',
-    sequence(
-      g.ContainerQueryAtom,
-      many(sequence(
-        g.QueryAndOr,
+    choice(
+      sequence(
+        g.QueryNot,
         g.ContainerQueryAtom
-      ))
+      ),
+      sequence(
+        g.ContainerQueryAtom,
+        many(sequence(
+          g.QueryAndOr,
+          g.ContainerQueryAtom
+        ))
+      )
     ),
     (children) => {
       const values = children

--- a/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
+++ b/packages/syntax/jess/jess-parser/test/ast-grammar.test.ts
@@ -1722,6 +1722,32 @@ describe('Jess AST grammar facts', () => {
         args: [{ value: { type: 'Operation', operator: ':' } }]
       }
     });
+
+    /*
+     * css-contain-3 §3 `<query-in-parens> = ( not <query-in-parens> )`: the
+     * leading-`not` arm negates its inner condition, including a `<style-query>`.
+     * The group wraps a `Sequence[not, Block(...)]`, matching what css/scss emit.
+     */
+    expect(parse('@container (not (width > 1px)) { .card { color: blue; } }').rules[0]).toMatchObject({
+      type: 'AtRuleBlock',
+      prelude: {
+        type: 'Block', delimiter: 'paren',
+        value: { type: 'Sequence', parts: [
+          { type: 'Keyword', src: 'not' },
+          { type: 'Block', delimiter: 'paren', value: { type: 'Operation', operator: '>' } }
+        ] }
+      }
+    });
+    expect(parse('@container (not (style(--x: 1))) { .card { color: blue; } }').rules[0]).toMatchObject({
+      type: 'AtRuleBlock',
+      prelude: {
+        type: 'Block', delimiter: 'paren',
+        value: { type: 'Sequence', parts: [
+          { type: 'Keyword', src: 'not' },
+          { type: 'Block', delimiter: 'paren', value: { type: 'FunctionCall', name: 'style' } }
+        ] }
+      }
+    });
   });
 
   it('constructs a media feature <ratio> value in every static query form', () => {

--- a/packages/syntax/jess/jess-parser/test/conditional-at-rule-value.test.ts
+++ b/packages/syntax/jess/jess-parser/test/conditional-at-rule-value.test.ts
@@ -190,7 +190,9 @@ const COMPOSITION: Array<[string, string, object]> = [
   ['a list whose first query is an and chain', '@media screen and (hover), print { a { color: red; } }',
     list({ type: 'Sequence', parts: [kw('screen'), kw('and'), paren(kw('hover'))] }, kw('print'))],
   ['a comma-separated @container query list', '@container (width > 1px), (height > 1px) { a { color: red; } }',
-    list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))]
+    list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))],
+  ['a negated @container query-in-parens', '@container (not (width > 1px)) { a { color: red; } }',
+    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })]
 ];
 
 /**

--- a/packages/syntax/less/less-parser/test/conditional-at-rule-value.test.ts
+++ b/packages/syntax/less/less-parser/test/conditional-at-rule-value.test.ts
@@ -190,7 +190,9 @@ const COMPOSITION: Array<[string, string, object]> = [
   ['a list whose first query is an and chain', '@media screen and (hover), print { a { color: red; } }',
     list({ type: 'Sequence', parts: [kw('screen'), kw('and'), paren(kw('hover'))] }, kw('print'))],
   ['a comma-separated @container query list', '@container (width > 1px), (height > 1px) { a { color: red; } }',
-    list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))]
+    list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))],
+  ['a negated @container query-in-parens', '@container (not (width > 1px)) { a { color: red; } }',
+    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })]
 ];
 
 /**

--- a/packages/syntax/scss/scss-parser/test/conditional-at-rule-value.test.ts
+++ b/packages/syntax/scss/scss-parser/test/conditional-at-rule-value.test.ts
@@ -190,7 +190,9 @@ const COMPOSITION: Array<[string, string, object]> = [
   ['a list whose first query is an and chain', '@media screen and (hover), print { a { color: red; } }',
     list({ type: 'Sequence', parts: [kw('screen'), kw('and'), paren(kw('hover'))] }, kw('print'))],
   ['a comma-separated @container query list', '@container (width > 1px), (height > 1px) { a { color: red; } }',
-    list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))]
+    list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))],
+  ['a negated @container query-in-parens', '@container (not (width > 1px)) { a { color: red; } }',
+    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })]
 ];
 
 /**


### PR DESCRIPTION
## The gap

The Jess grammar rejected `@container (not (width > 1px))` with "Unexpected
Jess syntax", while the CSS, Less, and SCSS grammars all accept it.

`( not <query-in-parens> )` is spec-valid — css-contain-3 §3 defines
`<query-in-parens>` as `( <container-query> )` and `<container-query>` as
`not <query-in-parens> | <query-in-parens> [ and … | or … ]`. Valid CSS must
parse in every dialect, so a superset dialect rejecting it is a correctness
gap.

## The fix

CSS carries the boolean in `ContainerQueryCondition` (the production
`ContainerQueryInParens` wraps). Jess folds that into a single
`ContainerQueryClause`, which matched only `<atom> ( and | or <atom> )*` — no
leading-`not` arm.

Added the `not` arm to that clause:

```ts
choice(
  sequence(g.QueryNot, g.ContainerQueryAtom),
  sequence(g.ContainerQueryAtom, many(sequence(g.QueryAndOr, g.ContainerQueryAtom))),
)
```

- Mirrors CSS's shape and emits the identical node,
  `Block(Sequence[Keyword(not), Block(...)])`.
- Reuses the shared `QueryNot` / `QueryAndOr` terminals — no new or
  dialect-prefixed rule.
- The reducer already lowered `not` / `and` / `or` tokens to keywords, so it
  is unchanged.
- Purely additive: any input not starting with `not` fails the first arm on
  its first token and falls through to the original body, so existing parses
  are byte-identical.

The clause is used recursively inside `ContainerQueryInParens`, so Jess now
also accepts two further spec-valid forms CSS still rejects —
`@container (a) and (not (b))` and bare top-level `@container not (a)`. Jess
is the more spec-compliant side here; the follow-up is to widen CSS, not to
narrow Jess.

## Red → green

- Before: Jess threw `Unexpected Jess syntax` on both
  `@container (not (width > 1px))` and `@container (not (style(--x: 1)))`;
  CSS/SCSS accepted both and Less accepted the size-feature form.
- After: all pass.

Tests:

- The shared `conditional-at-rule-value` matrix (replicated across
  css/less/scss/jess) gains a negated `@container (not (width > 1px))` case,
  asserting the same canonical AST in all four dialects.
- `jess-parser` `ast-grammar` adds the size-feature and `style()` negated
  forms (the latter is Jess/CSS/SCSS-only, since Less has no typed
  style-query atom).

Full `jess-parser` suite (531), the macro-buildability gate, and whole-file
ESLint on the grammar are green.
