### PR TITLE
fix(css): accept @container 'not (…)' and mixed logical negation

### DIFF
--- a/packages/syntax/css/css-parser/src/grammar.ts
+++ b/packages/syntax/css/css-parser/src/grammar.ts
@@ -3086,6 +3086,17 @@ const cssFactory = (g: GrammarSelf) => {
     ),
     children => block(firstValue(children))
   );
+
+  /*
+   * The top-level `<container-query>` of a `@container` prelude (css-contain-3
+   * §3): a first size feature, style query or grouped condition, then an
+   * `and`/`or` chain. Each chain operand is a `QueryTerm` OR a
+   * `ContainerQueryInParens`, so a grouped or negated operand — `(a) and (not
+   * (b))`, `(a) or ((b) and (c))` — routes through the same `( <condition> )`
+   * group the first atom uses instead of being rejected as a non-feature. A
+   * plain `(feature)` operand still falls to `QueryTerm` because its interior is
+   * not another condition, keeping existing single-feature chains byte-identical.
+   */
   const ContainerQueryClause = node(
     'ContainerQueryClause',
     sequence(
@@ -3094,7 +3105,10 @@ const cssFactory = (g: GrammarSelf) => {
         g.QueryFeature,
         g.QueryFunction
       ),
-      many(g.QueryTerm)
+      many(choice(
+        g.QueryTerm,
+        g.ContainerQueryInParens
+      ))
     ),
     (children) => {
       const values = valueChildren(children);

--- a/packages/syntax/css/css-parser/test/conditional-at-rule-value.test.ts
+++ b/packages/syntax/css/css-parser/test/conditional-at-rule-value.test.ts
@@ -192,7 +192,12 @@ const COMPOSITION: Array<[string, string, object]> = [
   ['a comma-separated @container query list', '@container (width > 1px), (height > 1px) { a { color: red; } }',
     list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))],
   ['a negated @container query-in-parens', '@container (not (width > 1px)) { a { color: red; } }',
-    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })]
+    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })],
+  ['a bare negation in @container', '@container not (width > 1px) { a { color: red; } }',
+    { type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] }],
+  ['a negated operand in an @container and-chain', '@container (width > 1px) and (not (height > 1px)) { a { color: red; } }',
+    { type: 'Sequence', parts: [paren(op('>', kw('width'), dim('1px'))), kw('and'),
+      paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('height'), dim('1px')))] })] }]
 ];
 
 /**

--- a/packages/syntax/jess/jess-parser/test/conditional-at-rule-value.test.ts
+++ b/packages/syntax/jess/jess-parser/test/conditional-at-rule-value.test.ts
@@ -192,7 +192,12 @@ const COMPOSITION: Array<[string, string, object]> = [
   ['a comma-separated @container query list', '@container (width > 1px), (height > 1px) { a { color: red; } }',
     list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))],
   ['a negated @container query-in-parens', '@container (not (width > 1px)) { a { color: red; } }',
-    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })]
+    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })],
+  ['a bare negation in @container', '@container not (width > 1px) { a { color: red; } }',
+    { type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] }],
+  ['a negated operand in an @container and-chain', '@container (width > 1px) and (not (height > 1px)) { a { color: red; } }',
+    { type: 'Sequence', parts: [paren(op('>', kw('width'), dim('1px'))), kw('and'),
+      paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('height'), dim('1px')))] })] }]
 ];
 
 /**

--- a/packages/syntax/less/less-parser/test/conditional-at-rule-value.test.ts
+++ b/packages/syntax/less/less-parser/test/conditional-at-rule-value.test.ts
@@ -192,7 +192,12 @@ const COMPOSITION: Array<[string, string, object]> = [
   ['a comma-separated @container query list', '@container (width > 1px), (height > 1px) { a { color: red; } }',
     list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))],
   ['a negated @container query-in-parens', '@container (not (width > 1px)) { a { color: red; } }',
-    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })]
+    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })],
+  ['a bare negation in @container', '@container not (width > 1px) { a { color: red; } }',
+    { type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] }],
+  ['a negated operand in an @container and-chain', '@container (width > 1px) and (not (height > 1px)) { a { color: red; } }',
+    { type: 'Sequence', parts: [paren(op('>', kw('width'), dim('1px'))), kw('and'),
+      paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('height'), dim('1px')))] })] }]
 ];
 
 /**

--- a/packages/syntax/scss/scss-parser/test/conditional-at-rule-value.test.ts
+++ b/packages/syntax/scss/scss-parser/test/conditional-at-rule-value.test.ts
@@ -192,7 +192,12 @@ const COMPOSITION: Array<[string, string, object]> = [
   ['a comma-separated @container query list', '@container (width > 1px), (height > 1px) { a { color: red; } }',
     list(paren(op('>', kw('width'), dim('1px'))), paren(op('>', kw('height'), dim('1px'))))],
   ['a negated @container query-in-parens', '@container (not (width > 1px)) { a { color: red; } }',
-    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })]
+    paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] })],
+  ['a bare negation in @container', '@container not (width > 1px) { a { color: red; } }',
+    { type: 'Sequence', parts: [kw('not'), paren(op('>', kw('width'), dim('1px')))] }],
+  ['a negated operand in an @container and-chain', '@container (width > 1px) and (not (height > 1px)) { a { color: red; } }',
+    { type: 'Sequence', parts: [paren(op('>', kw('width'), dim('1px'))), kw('and'),
+      paren({ type: 'Sequence', parts: [kw('not'), paren(op('>', kw('height'), dim('1px')))] })] }]
 ];
 
 /**


### PR DESCRIPTION
## What

Two spec-valid `@container` prelude forms (css-contain-3 §3):

- **(a)** bare negation — `@container not (width > 1px)`
- **(b)** negated/grouped operand in a chain — `@container (width > 1px) and (not (height > 1px))`

Rebased onto `dev` after #157 (which added jess's leading-`not` arm and pinned the `(not (…))` group form). This PR is now the remaining delta.

## The gap (built tree)

Form (b) was rejected by **css**; less/scss already accepted it. Form (a) already parsed everywhere. After #157, **jess** accepts both (a) and (b) already — the inner `(not (…))` operand recurses through `ContainerQueryAtom → ContainerQueryInParens → ContainerQueryClause`, whose leading-`not` arm #157 added — so **no jess grammar change is needed here**; only css does.

## Fix — one css grammar change, additive

**css `ContainerQueryClause`**: the `and`/`or` tail operand changes from `many(QueryTerm)` to `many(choice(QueryTerm, ContainerQueryInParens))`. A grouped/negated operand now routes through the same `( <condition> )` group the first atom uses — `ContainerQueryInParens` already wraps `ContainerQueryCondition`, which carries the leading-`not` arm. A plain `(feature)` operand still falls to `QueryTerm` (its interior is not another condition), so existing single-feature chains are byte-identical.

No new rule invented, no dialect-prefixed name, reducer unchanged. jess/less/scss grammars untouched.

## Tests

Both forms added to the shared `conditional-at-rule-value` matrix across css/less/scss/jess, alongside #157's `(not (…))` case. All four dialects parse all three forms to **identical AST**.

## Verification (post-rebase)

- All four dialects: forms (a), (b), and #157's `(not (…))` parse to identical AST (checked programmatically).
- `conditional-at-rule-value` matrix green in all four (css 110; less/scss/jess exit 0).
- css byte-identity oracle: **63/63 identical, 0 divergent**, negative controls pass.
- `check:macro`: **0 interpreter fallbacks** across all parsers.
- css grammar `eslint` clean.
- grammar-reviewer approved the css change (evidence per const; hard rules 1/3/4 pass; rule-2 composition debt pre-existing, not worsened).
