### PR TITLE
docs: document ::=, SCSS diagnostics, unit mode, and loop reassignment

### DIFF
--- a/packages/docs/docs-content/docs/jess/02-Language/02-variables.mdx
+++ b/packages/docs/docs-content/docs/jess/02-Language/02-variables.mdx
@@ -42,27 +42,65 @@ $color: red;
 
 ## Declarations and assignments
 
-Both `$foo: value` and `$^foo: value` create or update **both** the live and
-scoped bindings. The sigil changes lookup behavior, not the kind of binding
-created.
+There are four assignment operators. They differ only in **which binding they
+write** and **what happens when the name is not yet bound**:
 
-| Form | Lookup used by the operation |
-| --- | --- |
-| `$foo?: value` | Test the live map; create/update both bindings if absent. |
-| `$^foo?: value` | Test the scoped/final map; create/update both bindings if absent. |
-| `$foo := value` | Update the live/current binding. |
-| `$^foo := value` | Update the scoped/final binding. |
+| Operator | Name | What it does |
+| --- | --- | --- |
+| `$x: value` | declare | Bind `x` in the current scope. If an outer scope already binds `x`, this **shadows** it locally — the outer binding is left untouched. |
+| `$x := value` | reassign | Write the **nearest existing** binding, wherever it lives up the scope chain. If `x` is not bound anywhere, this is a **compile error**. |
+| `$x?: value` | assign-if-unset | Bind `x` **only if it is not already bound**. If `x` already has a value, nothing happens. This is the equivalent of Sass's `!default`. |
+| `$x ::= value` | optional shadow | Write the nearest existing binding, or — if `x` is unbound anywhere — declare it locally. It always writes; only the fallback declaration is conditional. |
 
-```scss
-$theme: blue;       // creates both bindings (`$^theme: blue` does too)
-.card {
-  color: $theme;    // live reference
-  border: $^theme;  // scoped/final lookup
-}
+```less
+$x: 1;
+$x := 2;
+.a { width: $x; }   // 2 — reassigned the existing binding
 ```
 
-SCSS retains its own `$name: value`, `!default`, and `!global` syntax at the
-input boundary; see [Sass (SCSS) compatibility](/docs/guides/coming-from-sass/scss-compatibility).
+Reassigning a name that does not exist is an error, rather than quietly
+creating it:
+
+```less
+$x := 2;            // error: live variable $x is undefined
+```
+
+`?:` assigns only when the name is unset, so an earlier value wins:
+
+```less
+$brand: #06c;
+$brand?: #f00;
+.a { color: $brand; }   // #06c — the ?: was skipped
+```
+
+### `::=` is for Sass conversion, not hand-written Jess
+
+`::=` exists so an automated SCSS-to-Jess conversion can preserve one Sass rule:
+a bare `$x:` written inside a control-flow block reassigns an outer variable when
+one exists, which is what a `@for` / `@each` / `@while` accumulator relies on.
+When Jess reads SCSS, it lowers those in-loop `$x:` declarations to `::=` for you.
+
+In hand-written `.jess`, prefer the explicit operators — `:` when you mean
+"declare here" and `:=` when you mean "reassign an existing variable." Reach for
+`::=` only when you genuinely want "reassign if it exists, otherwise declare."
+
+### Scope
+
+A declaration's scope is the nearest enclosing **ruleset, mixin, or function
+body** — those are the `{ }` blocks that open a scope. Control-flow blocks
+(`$if` / `$for` / `$while`) do **not** open a scope: a `:` declaration inside one
+stays visible in the surrounding block after it, which is what lets a loop build
+up a value (see [Conditionals and iteration](./conditionals-iteration)).
+
+### Live and scoped forms
+
+Every operator also has a `$^` scoped/final form (`$^x: …`, `$^x := …`,
+`$^x?: …`). The sigil chooses which lookup the write and later reads use — live
+(`$x`) or scoped/final (`$^x`) — as described above; it does not change the kind
+of binding created.
+
+SCSS keeps its own `$name: value`, `!default`, and `!global` syntax at the input
+boundary; see [Sass (SCSS) compatibility](/docs/guides/coming-from-sass/scss-compatibility).
 
 ## Block-valued assignments
 

--- a/packages/docs/docs-content/docs/shared/04-guides/02-coming-from-sass/00-support-matrix.mdx
+++ b/packages/docs/docs-content/docs/shared/04-guides/02-coming-from-sass/00-support-matrix.mdx
@@ -91,7 +91,7 @@ Jess spends its complexity budget — not a verdict on Sass's design.
 | `math.div` | ⏳ | Use `($a / $b)` today. |
 | String concatenation — `"a" + "b"` | ❓ | Renders as a `calc()` expression rather than a joined string. Interpolation — `"#{$a}#{$b}"` — is the working spelling. |
 | `@media` bubbling, nested `@supports` | ✅ | Including a `@media` block written inside a mixin. |
-| `@debug` / `@warn` / `@error` | ⏳ | |
+| `@debug` / `@warn` / `@error` | ✅ | Recognized SCSS diagnostics; none emit CSS. `@warn` / `@debug` report a message and let the compile continue; `@error` aborts it. |
 | `sass:` built-in modules — `sass:math`, `sass:map`, `sass:string`, `sass:list` | ⏳ | `@use "sass:math"` parses; the module is not loaded and its members are unreachable. |
 | Color functions — `rgba`, `darken`, `lighten` | ✅ | |
 | `if()`, `length()`, `percentage()` | ✅ | |
@@ -465,6 +465,26 @@ A `@media` block inside a mixin bubbles the same way:
   /* shipped */
 }
 ```
+
+### Compile-time diagnostics
+
+`@warn` reports a message during compilation and lets it continue; the CSS is
+still produced:
+
+```scss
+@warn "use the spacing tokens instead";
+.a { color: red; }
+```
+
+```css
+.a {
+  color: red;
+}
+```
+
+`@error` reached during evaluation stops the compile with its message, and
+`@debug` behaves like `@warn` without the warning severity. None of the three
+emit CSS.
 
 ## How much of a real codebase this covers
 

--- a/packages/docs/docs-content/docs/shared/04-guides/02-coming-from-sass/01-scss-compatibility.mdx
+++ b/packages/docs/docs-content/docs/shared/04-guides/02-coming-from-sass/01-scss-compatibility.mdx
@@ -199,3 +199,54 @@ Sass supports `!global` and `!default` on variable assignments ([variables](http
 Jess’s SCSS support intentionally does **not** implement Sass’s full `!global` shadowing model. It lowers `!global` to the scoped/final set-existing/no-shadow operation (`$^name := value`). SCSS `!default` corresponds to the scoped/final conditional operation (`$^name?: value`). Both `$name:` and `$^name:` create or update both bindings in native Jess.
 
 `!default` exists in Sass primarily to support module configuration (`@use ... with (...)`). Jess will align with Sass’s `@use` configuration behavior by ensuring configurable variables are explicitly marked and handled accordingly.
+
+## Accumulating a variable inside a loop
+
+Sass lets a bare `$x:` inside a control-flow block update a variable declared
+outside it — the pattern behind a running total. Jess preserves this:
+
+```scss
+$sum: 0;
+@for $i from 1 through 3 {
+  $sum: $sum + $i;
+}
+.total { width: $sum; }
+```
+
+```css
+.total {
+  width: 6;
+}
+```
+
+Inside `@if` / `@else` / `@for` / `@each` / `@while`, a bare `$x:` reassigns the
+nearest existing binding, and only declares a new block-local variable when the
+name is not bound anywhere. A `$x:` at the top level, or directly inside a
+ruleset, stays an ordinary declaration. This is the same "optional shadow" write
+that native Jess spells [`::=`](/docs/Language/variables) — reading SCSS lowers
+in-loop declarations to it so accumulators behave as they do in Sass.
+
+## Compile-time diagnostics: `@debug`, `@warn`, `@error`
+
+Sass's diagnostic at-rules are recognized. They never produce CSS:
+
+- `@debug "…";` and `@warn "…";` surface a message during compilation and let it
+  continue.
+- `@error "…";` aborts the compile with its message.
+
+```scss
+@warn "use the spacing tokens instead";
+.a { color: red; }
+```
+
+```css
+.a {
+  color: red;
+}
+```
+
+The `@warn` message is reported during compilation; the CSS is still produced. An
+`@error` reached during evaluation stops the compile with its message instead.
+
+These are SCSS-only. In native `.jess` (and in CSS and Less) `@debug` / `@warn` /
+`@error` are not diagnostic directives.


### PR DESCRIPTION
## What this does

Documents recently-landed language decisions that had not reached the Docusaurus
docs. Every claim below was verified by compiling the construct through the
shipping Jess compiler (`renderString` / SCSS pipeline), not from memory.

### Changes

- **Assignment operator family** — `packages/docs/.../02-Language/02-variables.mdx`
  now documents all four operators as a single family:
  - `$x: v` — declare in the current scope (shadows an outer binding locally)
  - `$x := v` — reassign the nearest existing binding; **compile error** if the name is unbound anywhere
  - `$x?: v` — assign only if unset (the equivalent of Sass `!default`)
  - `$x ::= v` — optional shadow: reassign the nearest existing binding, else declare locally
  - `::=` is documented as intended for **Sass conversion, not hand-written Jess** (prefer explicit `:` / `:=`), plus a short scope note and the `$^` scoped/final forms.
- **SCSS compile-time diagnostics** — `01-scss-compatibility.mdx` gains a section on
  `@debug` / `@warn` / `@error`: recognized, emit no CSS, `@warn`/`@debug` report and
  continue, `@error` aborts; SCSS-only. The Sass+ support-matrix row is corrected
  from ⏳ to ✅ with a compiled sample.
- **In-loop accumulation** — `01-scss-compatibility.mdx` documents that a bare `$x:`
  inside `@if`/`@else`/`@for`/`@each`/`@while` reassigns the outer binding (the
  accumulator pattern), the same optional-shadow write native Jess spells `::=`.

## Verification

- `pnpm --filter @jesscss/docs-content validate` → passes (133 files).
- `build:facings` materializes cleanly (60 jess / 77 less docs).
- Docusaurus webpack client+server bundles compile successfully with the edits.
- Note: the full `docusaurus build` SSG step currently fails in this environment
  with `require.resolveWeak is not a function` — a Docusaurus 3.8.1 / Node 24
  toolchain incompatibility unrelated to content (both bundles compile). This is
  pre-existing.

## Audit — gap list

**Covered in this PR**

| Gap | Status |
| --- | --- |
| Assignment operators `:` / `:=` / `?:` / `::=` (semantics + error-on-unbound + `::=` guidance) | ✅ documented |
| SCSS `@debug` / `@warn` / `@error` (report/halt, no CSS, SCSS-only) | ✅ documented + matrix row fixed |
| In-loop variable accumulation (bare `$x:` reassigns outer) | ✅ documented |
| Assignment scope (rulesets/mixins/functions are scopes; control-flow blocks are not) | ✅ documented |

**Verified already-accurate (no change needed)**

| Topic | Where | Finding |
| --- | --- | --- |
| Unit mode `preserve` (default) / `strict` / `loose`; `strictUnits` deprecated alias | `less/usage/less-options.md` | Already documented and matches the code (`preserve` = strict-without-error → `calc(…)`; verified `1px + 2em` → `calc(1px + 2em)`). |
| `@content` block-less `@include` divergence (raises vs dart-sass no-op) | `coming-from-sass/04-semantic-differences.mdx` | Accurate — a block-less `@include` reaching `@content` raises "Name not found", confirmed by compiling. |
| `!global` / `!default` mapping | `coming-from-sass/01-scss-compatibility.mdx` | Accurate. |

**Deferred (follow-ups — verified stale, out of this PR's named scope)**

The Sass+ **support matrix** (`00-support-matrix.mdx`) has drifted: several ⏳
rows now compile. Refreshing it properly means re-running each sample and
reconciling the Bootstrap-corpus narrative, so it is left as a dedicated pass.
Verified-stale rows:

- `@content` + `@include` with a block (row still ⏳ / "largest gap"): `@include m { … }` and `@include m() { … }` now compile, and bare `@content` works. `@include … using ()` and parameterized `@content($x)` still fail ("Name not found"). This row also contradicts the (accurate) `04-semantic-differences` `@content` section today.
- `@while` (⏳): both `@while $i < 2` and `@while ($i < 2)` now compile, including accumulator loops.
- Bare-truthy `@if $x` (⏳): `@if $x` now compiles (`not $x` / `@if fn($x)` not re-verified).

Other observations for a future pass:

- The Jess **Conditionals and iteration** page states control-flow blocks share
  the enclosing scope (verified for `$if`), but a `.jess` `$for` accumulator with a
  bare `$sum:` did not accumulate in a quick probe (`.scss` does). Worth a focused
  investigation before documenting `.jess` loop accumulation — possibly an engine
  gap rather than a docs gap.
- The `output.collapseNesting` option did not flatten `@content`-injected nested
  rules in a probe; unconfirmed whether that is expected.

Do not self-merge.
