### PR TITLE
test(scss-parser): raise macro-fuse test timeout to 60s

### DIFF
--- a/packages/syntax/scss/scss-parser/test/ast-macro-compiled.test.ts
+++ b/packages/syntax/scss/scss-parser/test/ast-macro-compiled.test.ts
@@ -36,7 +36,7 @@ test('canonical SCSS grammar macro-fuses recognition leaves with no runtime impo
   } finally {
     await server.close();
   }
-});
+}, 60000); // ponytail: macro-fuses the whole SCSS grammar (a slow one-time build); 30s default flakes under CI load
 
 test('compiler-facing SCSS entrypoint does not load the CST grammar', async () => {
   const server = await createServer({


### PR DESCRIPTION
The `ast-macro-compiled` test "canonical SCSS grammar macro-fuses recognition leaves with no runtime import" macro-compiles the entire SCSS grammar in one shot — an inherently slow one-time build. Under CI load it runs ~32s and trips vitest's 30s default, so the "Source tests (build-free)" job has needed manual re-runs to go green (seen on #168 and #169).

Raise that single test's timeout to 60s. No work is skipped or reduced; the change is scoped to the one test.

Verified locally with `pnpm --filter scss-parser test ast-macro-compiled` — passes (~14.5s here).