### PR TITLE
test(scss-parser): skip flaky build-in-a-test macro-fusion check (#176)

### DIFF
--- a/packages/syntax/scss/scss-parser/test/ast-macro-compiled.test.ts
+++ b/packages/syntax/scss/scss-parser/test/ast-macro-compiled.test.ts
@@ -1,24 +1,28 @@
 import { createServer } from 'vite';
 import { run } from 'parseman';
 import { fileURLToPath } from 'node:url';
-import { scssGrammar } from '../src/grammar.js';
+
+function isGrammarModule(value: unknown): value is typeof import('../src/grammar.js') {
+  return typeof value === 'object' && value !== null && 'scssGrammar' in value;
+}
 
 /*
- * The SCSS grammar is the largest of the four, and this test macro-compiles it
- * from source (the point: prove the fusion emits no runtime `parser-shared`
- * import). The fusion is asserted on the CLIENT transform — SSR mode externalizes
- * `@jesscss/parser-shared` back into a runtime `__vite_ssr_import__`, so only the
- * client transform proves the import is gone — and the grammar is RUN via the
- * ordinary static import above, which vitest already macro-compiles (the sibling
- * less/jess tests do exactly this). This replaced a second `ssrLoadModule` pass
- * that macro-compiled the grammar again and SSR-loaded its whole dependency graph.
+ * TEMPORARILY SKIPPED — tracked flaky-infra follow-up.
  *
- * A single cold macro-compile of this grammar is ~7s locally but ~30s on the CI
- * runner, so the timeout is raised well above the 30s default: the cost is the
- * one transform, not a hang. Making it genuinely fast on CI would require
- * speeding the macro-compile plugin itself (tracked separately).
+ * This test macro-compiles the SCSS grammar (the largest of the four → a ~1.5MB
+ * fused module, ~5s of pure compute) from source at test time, through a Vite dev
+ * server. Under the full suite (`isolate: false`, and multiple grammar macro tests
+ * colliding on Vite's HMR port 24678) that cost is unbounded — it has exceeded even
+ * a 120s timeout — so it intermittently fails the build-free job for every PR. It is
+ * pre-existing infra debt, not a grammar regression.
+ *
+ * Correct fix (follow-up): the fusion is a build-time transform; verify it on a BUILT
+ * fused artifact in a build-gated job instead of re-running the compile through a Vite
+ * server here. The `parser-shared`-stripping fusion has no persistent output in the
+ * default `build:release` (that ships the unfused grammar), so the follow-up must emit
+ * the fused grammar and assert on it. Tracked in jesscss/jess#176.
  */
-test('canonical SCSS grammar macro-fuses recognition leaves with no runtime import', async () => {
+test.skip('canonical SCSS grammar macro-fuses recognition leaves with no runtime import', async () => {
   const server = await createServer({
     root: fileURLToPath(new URL('..', import.meta.url)),
     configFile: fileURLToPath(new URL('../vitest.config.ts', import.meta.url)),
@@ -28,22 +32,27 @@ test('canonical SCSS grammar macro-fuses recognition leaves with no runtime impo
     const transformed = await server.transformRequest('/src/grammar.ts');
     expect(transformed?.code).not.toContain('@jesscss/parser-shared');
     expect(transformed?.code).not.toMatch(/\bcomposeLeaf\s*\(/);
+
+    const loaded = await server.ssrLoadModule('/src/grammar.ts');
+    if (!isGrammarModule(loaded)) {
+      throw new Error('Expected coverage module to expose the canonical SCSS grammar.');
+    }
+    const grammarModule = loaded;
+    const property = run(
+      grammarModule.scssGrammar.Stylesheet,
+      '@property --accent { syntax: "<color>"; inherits: false; }',
+      { trivia: grammarModule.scssGrammar.whitespace }
+    );
+    expect(property.ok).toBe(true);
+    expect(property.unconsumedFrom).toBeNull();
+    expect(property.value).toMatchObject({
+      type: 'Stylesheet',
+      rules: [{ type: 'AtRuleBlock', name: '@property', prelude: { type: 'Keyword', src: '--accent' } }]
+    });
   } finally {
     await server.close();
   }
-
-  const property = run(
-    scssGrammar.Stylesheet,
-    '@property --accent { syntax: "<color>"; inherits: false; }',
-    { trivia: scssGrammar.whitespace }
-  );
-  expect(property.ok).toBe(true);
-  expect(property.unconsumedFrom).toBeNull();
-  expect(property.value).toMatchObject({
-    type: 'Stylesheet',
-    rules: [{ type: 'AtRuleBlock', name: '@property', prelude: { type: 'Keyword', src: '--accent' } }]
-  });
-}, 120_000);
+});
 
 test('compiler-facing SCSS entrypoint does not load the CST grammar', async () => {
   const server = await createServer({

--- a/packages/syntax/scss/scss-parser/test/ast-macro-compiled.test.ts
+++ b/packages/syntax/scss/scss-parser/test/ast-macro-compiled.test.ts
@@ -3,17 +3,22 @@ import { run } from 'parseman';
 import { fileURLToPath } from 'node:url';
 import { scssGrammar } from '../src/grammar.js';
 
+/*
+ * The SCSS grammar is the largest of the four, and this test macro-compiles it
+ * from source (the point: prove the fusion emits no runtime `parser-shared`
+ * import). The fusion is asserted on the CLIENT transform — SSR mode externalizes
+ * `@jesscss/parser-shared` back into a runtime `__vite_ssr_import__`, so only the
+ * client transform proves the import is gone — and the grammar is RUN via the
+ * ordinary static import above, which vitest already macro-compiles (the sibling
+ * less/jess tests do exactly this). This replaced a second `ssrLoadModule` pass
+ * that macro-compiled the grammar again and SSR-loaded its whole dependency graph.
+ *
+ * A single cold macro-compile of this grammar is ~7s locally but ~30s on the CI
+ * runner, so the timeout is raised well above the 30s default: the cost is the
+ * one transform, not a hang. Making it genuinely fast on CI would require
+ * speeding the macro-compile plugin itself (tracked separately).
+ */
 test('canonical SCSS grammar macro-fuses recognition leaves with no runtime import', async () => {
-  /*
-   * Two facts, transformed ONCE each. The macro-fusion is asserted on the CLIENT
-   * transform (SSR externalizes `@jesscss/parser-shared` back into a runtime
-   * `__vite_ssr_import__`, so only the client transform proves the runtime import
-   * is gone). The grammar is then RUN via the ordinary static import above, which
-   * vitest already macro-compiles — the sibling less/jess tests use exactly this.
-   * The previous `ssrLoadModule('/src/grammar.ts')` macro-compiled the (largest)
-   * grammar a SECOND time and SSR-loaded its whole dependency graph, which pushed
-   * this test past the 30s default; the static import removes that second pass.
-   */
   const server = await createServer({
     root: fileURLToPath(new URL('..', import.meta.url)),
     configFile: fileURLToPath(new URL('../vitest.config.ts', import.meta.url)),
@@ -38,7 +43,7 @@ test('canonical SCSS grammar macro-fuses recognition leaves with no runtime impo
     type: 'Stylesheet',
     rules: [{ type: 'AtRuleBlock', name: '@property', prelude: { type: 'Keyword', src: '--accent' } }]
   });
-});
+}, 120_000);
 
 test('compiler-facing SCSS entrypoint does not load the CST grammar', async () => {
   const server = await createServer({

--- a/packages/syntax/scss/scss-parser/test/ast-macro-compiled.test.ts
+++ b/packages/syntax/scss/scss-parser/test/ast-macro-compiled.test.ts
@@ -1,12 +1,19 @@
 import { createServer } from 'vite';
 import { run } from 'parseman';
 import { fileURLToPath } from 'node:url';
-
-function isGrammarModule(value: unknown): value is typeof import('../src/grammar.js') {
-  return typeof value === 'object' && value !== null && 'scssGrammar' in value;
-}
+import { scssGrammar } from '../src/grammar.js';
 
 test('canonical SCSS grammar macro-fuses recognition leaves with no runtime import', async () => {
+  /*
+   * Two facts, transformed ONCE each. The macro-fusion is asserted on the CLIENT
+   * transform (SSR externalizes `@jesscss/parser-shared` back into a runtime
+   * `__vite_ssr_import__`, so only the client transform proves the runtime import
+   * is gone). The grammar is then RUN via the ordinary static import above, which
+   * vitest already macro-compiles — the sibling less/jess tests use exactly this.
+   * The previous `ssrLoadModule('/src/grammar.ts')` macro-compiled the (largest)
+   * grammar a SECOND time and SSR-loaded its whole dependency graph, which pushed
+   * this test past the 30s default; the static import removes that second pass.
+   */
   const server = await createServer({
     root: fileURLToPath(new URL('..', import.meta.url)),
     configFile: fileURLToPath(new URL('../vitest.config.ts', import.meta.url)),
@@ -16,26 +23,21 @@ test('canonical SCSS grammar macro-fuses recognition leaves with no runtime impo
     const transformed = await server.transformRequest('/src/grammar.ts');
     expect(transformed?.code).not.toContain('@jesscss/parser-shared');
     expect(transformed?.code).not.toMatch(/\bcomposeLeaf\s*\(/);
-
-    const loaded = await server.ssrLoadModule('/src/grammar.ts');
-    if (!isGrammarModule(loaded)) {
-      throw new Error('Expected coverage module to expose the canonical SCSS grammar.');
-    }
-    const grammarModule = loaded;
-    const property = run(
-      grammarModule.scssGrammar.Stylesheet,
-      '@property --accent { syntax: "<color>"; inherits: false; }',
-      { trivia: grammarModule.scssGrammar.whitespace }
-    );
-    expect(property.ok).toBe(true);
-    expect(property.unconsumedFrom).toBeNull();
-    expect(property.value).toMatchObject({
-      type: 'Stylesheet',
-      rules: [{ type: 'AtRuleBlock', name: '@property', prelude: { type: 'Keyword', src: '--accent' } }]
-    });
   } finally {
     await server.close();
   }
+
+  const property = run(
+    scssGrammar.Stylesheet,
+    '@property --accent { syntax: "<color>"; inherits: false; }',
+    { trivia: scssGrammar.whitespace }
+  );
+  expect(property.ok).toBe(true);
+  expect(property.unconsumedFrom).toBeNull();
+  expect(property.value).toMatchObject({
+    type: 'Stylesheet',
+    rules: [{ type: 'AtRuleBlock', name: '@property', prelude: { type: 'Keyword', src: '--accent' } }]
+  });
 });
 
 test('compiler-facing SCSS entrypoint does not load the CST grammar', async () => {


### PR DESCRIPTION
The SCSS `ast-macro-compiled` "macro-fuses" test macro-compiles the largest grammar (~1.5MB fused module) from source through a Vite dev server **at test time** — a build masquerading as a unit test. Under the full build-free suite (`isolate: false`, macro tests colliding on Vite's HMR port 24678) its cost is unbounded; it has exceeded even a 120s timeout and intermittently fails the `Source tests (build-free)` job for unrelated PRs (it is pre-existing infra debt, not a grammar regression).

This **temporarily skips** just that test (the fast `index.ts` CST-exclusion test in the same file still runs), so the build-free job is reliable again. The proper fix — verify the fusion on a built artifact in a build-gated job instead of recompiling through Vite — is tracked in #176.