### PR TITLE
perf(core): memoize member-lookup DeclMaps (pure builders) — cut 1

### DIFF
--- a/docs/design/MIXIN-SCOPING-AND-LOOKUP-MEMO.md
+++ b/docs/design/MIXIN-SCOPING-AND-LOOKUP-MEMO.md
@@ -1,0 +1,152 @@
+# Mixin scoping (caller-read leak) + member-lookup memoization — research & design
+
+Status: **DRAFT for review** (research complete; design proposed; not implemented).
+Scope: two intertwined changes to the live `ast/` evaluator (`packages/core/src/ast/serialize.ts`):
+- **A (semantics):** close the caller→body *variable read* leak for v5 (a mixin body should not read a free variable from its call site).
+- **B (perf):** memoize member-lookup `DeclMap` construction so `BASE[member]` accessed N times does not rebuild/re-dispatch N times.
+
+They are related: B's *mixin-call* case only becomes cleanly safe once A removes the caller-frame dependency, but B's *pure* cases (detached ruleset / collection / `@use` module) are safe regardless of A.
+
+---
+
+## 1. Motivation
+
+Measured on the live engine (instrumented counters, 236f11674):
+
+- `@p: .mk-map(); .a { a: @p[one]; … f: @p[two]; }` — 6 member reads → **12** `declMapFromMixinCall` dispatches (2× per access). Each dispatch re-runs `expandCall(.mk-map)` — **true re-evaluation** of the mixin body per access.
+- `@m: { … }; .a { a: @m[one]; … }` — 5 reads → **10** `evalToDeclMap` rebuilds (2× per access) — re-indexing the body per access.
+
+So repeated member lookups are O(accesses) × O(body), not O(1) amortized. This is the same "don't re-derive what one pass already produced" principle as the extend rework (ledger X12).
+
+Separately, the scoping question surfaced while designing the memo: a member lookup's result today can depend on the *call site's* variables (the leak), which both muddies the language rule and complicates any memo key.
+
+---
+
+## 2. Research findings (evidence)
+
+### 2.1 Current scoping model — lexical closure FIRST, caller-scope FALLBACK
+
+Empirically (live engine):
+
+| Case | Result | Meaning |
+|---|---|---|
+| `@x:DEF` (def) + `@x:CALLER` (call site), body reads `@x` | `DEF` | definition closure **wins** |
+| no def `@x`; call site `@x:5`; body reads `@x` | `5` | falls back to **caller** when closure misses |
+| nested `.outer→.inner`, `@x` only at outermost call site | `A_SCOPE` | fallback is **transitive** |
+| param `@x:PARAM` + caller `@x:CALLER` | `PARAM` | params shadow both |
+| caller `@x` defined *after* the read | `LATE` | scoped reads are lazy/last-wins (R2) |
+
+Mechanism — `expandCall` builds the body frame (`serialize.ts:12403-12413`):
+```
+parent   = homes.get(def) ?? frame     // the DEFINITION frame (closure)
+fallback = frame                        // the CALLER chain (the leak)   [only when not namespaced and homeFrame!==frame]
+```
+Variable lookup walks `parent` (closure) to root, THEN `fallback` (caller): `lookupScopedBinding` (`serialize.ts:2251-2294`), `lookupLiveCell` (`2180-2198`), dispatched by `resolveVarRef` (`2351-2354`). So a free `@x`/`$x` in a body resolves in the closure first and, on a miss, in the caller.
+
+### 2.2 The leak is unballoted, and unconditional in the live engine
+
+- **No ledger row governs the caller→body READ.** R2 (order-independent/last-wins), R9 (mixin var-unlock = the *reverse* body→caller leak, low-priority), R13 (`::=`, control blocks are scopes), R15 (`@content` args resolve in caller frame — OPEN) exist, but none states that a mixin body may read a caller-local variable. Closing it is therefore a **new OPEN decision**, not a change to a SETTLED row.
+- The `leakyScope`/`fallbackFrame` config knobs live only in the **dead `tree/` engine** (ledger E3); the live `ast/` path has **no flag** — the leak is the unconditional `fallback: frame` at `serialize.ts:12412`.
+
+### 2.3 `fallback` is dual-purpose (critical constraint)
+
+`fallback: frame` is not only the variable leak. Its comment (`serialize.ts:12397-12399`) and the recursion machinery show it also:
+- keeps the **dynamic expansion stack** reachable for the ruleset-mixin **parent-exclusion** recursion terminator (R8, `parentExcludes`), and
+- lets the body see **caller-published mixins/rulesets** (`publishOrderedMixins`/`publishExplicitRulesets`).
+
+⇒ Closing the *variable* leak must **separate variable resolution from `fallback`** — keep `fallback` for mixin/expansion-stack traversal, stop consulting it for variable reads — not delete `fallback`.
+
+### 2.4 Two binding stores + a third leak store
+
+- **Live (`$name`)**: `frame.cells` (newest-first), `lookupLiveCell`; order-dependent, never falls back to scoped.
+- **Scoped (`@name`/`$^name`)**: `declIndex` + per-activation `reassign` overlay, `lookupScopedBinding`; lazy/last-wins.
+- **Leaked (R9)**: `frame.leaked`, consulted ONLY as the last fallback of a *scoped* read. This is the body→caller unlock, orthogonal to the caller→body read we are closing.
+
+Both live and scoped reads traverse `parent` then `fallback`, so both currently leak from the caller.
+
+### 2.5 DeclMap build cost + side-effect surface
+
+No memoization on any builder (all in `serialize.ts`): `evalToDeclMap` (4571), `collectionToDeclMap` (4609), `declMapFromMixinCall` (4725), `resolveBaseDeclMap` (4643). Sole external entry: `resolveReferenceResult` (`5024`), run per member access during real render.
+
+- `evalToDeclMap` / `collectionToDeclMap` / the `Any`/`Keyword`/`resolveForRuleset` arms are **pure map construction** over statements — no dispatch, no frame mutation. Member *values* are stored unevaluated (`{name, value, frame}`) and evaluated lazily by the caller. **Safe to memoize.**
+- `declMapFromMixinCall` runs `expandCall` in a `scratchEmit` (output discarded) BUT passes the **real caller frame**, and `expandCall` mutates it **non-idempotently**: `leakBodyVars` (`12888-12894`) pushes leaked vars each call; `publishOrderedMixins`/`publishExplicitRulesets` append published mixins/rulesets. **Memoizing the dispatch is observationally unsafe** (changes accumulation counts) unless those mutations are excluded or proven idempotent, and its key would have to include the caller frame.
+
+### 2.6 Blast radius of closing the caller-read leak
+
+Narrow. In `less.js/packages/test-data` (315 `.less`), only **2** fixtures depend on a body reading a caller-local var: `scope/scope.less:63-79` (`sub-scope-only:'inside'`) and `detached-rulesets/detached-rulesets.less:6-25` (`four: magic-frame`). Everything else uses params, definition-scope closure, or globals. In jess: ~3 legacy `tree/__tests__/mixin.test.ts` scenarios. These are Less-4.x-expected outputs; v5 divergence here is consistent with the `.css`-fixtures-are-v5 policy.
+
+---
+
+## 3. Design A — close the caller→body variable read (v5 semantics)
+
+**Proposal.** A mixin/ruleset body resolves a free variable ONLY in its lexical closure (definition chain) plus its params. If unresolved there, it is undefined (error/verbatim per existing unresolved-var policy) — it does **not** read the call site's variables.
+
+**Scope — MIXIN-CALL bodies only (semantics review).** `fallback: callerFrame` is set at **five** construct sites, not one: `expandCall` mixin body (`serialize.ts:12412`), ruleset-mixin apply (`12636`), value-lambda / `result:` activation (`4888`), detached ruleset (`13096`), and partial-application frames (`13777`, `13801`). R16 governs **only the mixin-call body site(s)**. Detached rulesets and value-lambdas read the caller by **documented, intended Less design** (a detached ruleset reads variables from where it is called — `detached-rulesets.less:9` says so in-corpus), so closing *their* caller-read is a **separate OPEN question with its own evidence**, NOT part of R16. `@content`/`using(...)` bodies: R15 (arg binding in the caller frame) is untouched; a free-var read in a content-block body falls under the same separate question, not R16.
+
+**Mechanism (separating variable resolution from `fallback`).** At the mixin-call body site, variable lookups (`lookupScopedBinding`, `lookupLiveCell`) must **not** traverse `fallback`; keep `fallback` for the R8/publishing roles (§2.3). Concretely: tag the caller `fallback` at the mixin site so variable lookups skip it while `parentExcludes` (R8, `serialize.ts:2166`) and caller-published-mixin traversal keep it — or give the mixin body frame a "closure-only" variable-read mode. **`parentExcludes` MUST keep traversing the caller fallback** (it reaches the dynamic expansion stack) — this is the single largest implementation hazard the review flags. The R9 **body→caller** unlock (`leaked`) is unchanged — this closes only the READ direction.
+
+**Interactions preserved (review-confirmed consistent):** R2 (parent-chain order/last-wins — untouched), R8 (parent-exclusion — shares the `fallback` field, must keep traversing it), R13 (control blocks are `parent` scopes — orthogonal), R15 (`@content` args are bound as param cells, a different path from the `fallback` read — untouched).
+
+**Ledger.** New OPEN row (proposed **R16**), scoped to restate per-construct without a code path: "A v5 **mixin-call body** is a lexical closure — a free variable resolves in the mixin's definition scope + params only, never the call site. Closes Less's caller-scope fallback for mixin bodies (READ direction); the R9 body→caller unlock is unchanged; detached-ruleset / value-lambda / `@content`-body caller reads are a separate question." Owner-settle required (per E8).
+
+**Blast radius — MUST be a corpus differential, not inspection (review).** The "2 fixtures" figure (`scope/scope.less:63-79` — a mixin; `detached-rulesets/detached-rulesets.less:6-25` — a detached ruleset, hence OUT of R16's mixin-only scope) is `UNVERIFIED` until a real differential is run: v5 with the mixin caller-read closed, against all 315 `tests-unit`/`tests-config` `.less` **plus `tests-error/eval`** (caller-read cases that currently pass may start erroring) **plus the jess corpus**, with a **negative control**. Report the actual diff set before the owner rules on R16.
+
+**Fixtures & tests.** Record the intended v5 expectation for the affected fixtures on the less.js fork `alpha` BEFORE editing them (per S2 — do not read a green differential as validation). Add a test asserting the **rule** ("a mixin free var is NOT read from the call site → error/verbatim"), not just the new bytes, so a future re-widening of `fallback` fails (S7).
+
+**Doc-comment fix (independent of A).** `Frame.fallback`'s comment (`serialize.ts:610-614`) says detached rulesets are "caller-first, definition-fallback" — the code is **definition-first / caller-fallback**, same as mixins (`13091`/`13096`). Correct the comment regardless.
+
+---
+
+## 4. Design B — memoize member-lookup DeclMaps (perf)
+
+**Mechanism.** A plain `Map` on the resolving **frame** (render-scoped, disposed with the frame — **no WeakMap**; a node-keyed WeakMap would pin DeclMaps for the AST's whole cross-render lifetime, a leak, so the frame-owned Map is both leaner and the correct lifetime), keyed by the base value node identity: `frame.declMapMemo?: Map<node, DeclMap>`. The field is declared on `Frame` but assigned lazily (`??=`) **only on a frame that actually performs a lookup**, so non-lookup frames keep their current shape and allocate nothing.
+
+**Per-arm gating (required — perf review).** The memo is applied **only inside the three pure arms** of `resolveBaseDeclMap` — `Collection` (`4655`), `Any`/`Keyword` (`4673`), `resolveForRuleset` (`4696`) — NOT at the top of the function and NEVER on the `Reference` (`4651`), `MixinCall` (`4665`), or `Lookup`→mixin-call (`4711`) arms: those consult `e.excluded` (alias-cycle state, `4961`) and/or run `expandCall` (`4753`), so a node-keyed cache would replay a state-dependent result. The pure arms' only frame write is the timeline recording (`recordMapPropertyTimeline`/`recordCollectionPropertyTimeline`), which is write-once-guarded and would no-op on 2nd..Nth calls anyway — so skipping it on a memo hit is safe.
+
+**Computed-key edge (required — perf review).** An interpolated map key (`@{name}:`) evaluates via `evalBytesSync(name, frame, e)`, which could read `e.excluded`. Skip the memo-store when a build performed computed-key eval with non-empty `e.excluded` (static-string keys — the common case — are unaffected), or document it as a `ponytail:` ceiling.
+
+**Negative control (required — perf review).** Land behind a memo-disabled control run that reproduces the §1 counts (12 dispatches / 10 rebuilds); with the memo on, one build + N O(1) hits. A bare "counts dropped" is not a pass.
+
+**Why frame-keyed is correct.** After Design A, a body's members depend only on (node, definition scope, args), all fixed for a given binding; the resolving frame identity distinguishes distinct bindings/scopes. Even *before* A, keying on the resolving frame captures the caller scope (different call sites are different frames), and reassignment within a scope is already stable across accesses (measured `1,1`).
+
+**Safe scope now:** the pure builders — detached ruleset (`resolveForRuleset` arm), collection (`collectionToDeclMap`), and the `@use` module / `Any`/`Keyword` arms. **This covers the D18 module-access path**, which is the immediate consumer.
+
+**Deferred:** memoizing `declMapFromMixinCall` (the `@p: .mk()` dispatch) — the side-effect hazard (§2.5). Options for a follow-up: (i) run the dispatch once and cache both the DeclMap and a replay of its `leaked`/publish mutations, or (ii) make those mutations idempotent, or (iii) after Design A, evaluate a bound mixin-call value ONCE at binding (matching "a `@var` is one value") rather than lazily per access. Not in the first cut.
+
+**Value-eval memo (optional, later):** repeated reads of the *same* member re-evaluate that member's value. The dominant win is the index/dispatch; per-member value memo is a smaller, separable follow-up.
+
+---
+
+## 5. Cases matrix (target behavior)
+
+| Case | Today | After A+B |
+|---|---|---|
+| closed body member read | rebuild/re-index per access | one build, memoized |
+| def-scope free var | closure (correct) | unchanged; memoized |
+| caller-local free var read | reads caller (leak) | **undefined/error (A)**; memoized |
+| param free var | param wins | unchanged |
+| reassignment mid-scope | stable (`1,1`) | unchanged; memoized |
+| `@p: .mk()` dispatch ×N | N dispatches | pure cases memoized; mixin-call dispatch **deferred** |
+| R9 body→caller unlock | low-priority leak | unchanged |
+| `@content` args (R15) | caller-frame arg binding | unchanged |
+
+---
+
+## 6. Risks
+
+1. Closing the caller read is a Less-compat divergence (narrow: 2 fixtures) and needs an owner-settled ledger row (R16).
+2. `fallback` is load-bearing beyond variables — the fix must not sever recursion termination or caller-published-mixin visibility.
+3. `declMapFromMixinCall` memo is side-effect-unsafe as-is — deferred, not in the first cut.
+4. Detached-ruleset vs mixin precedence differ; confirm intended v5 behavior before generalizing A.
+5. R15 shares the caller-frame path; verify A leaves `@content` arg binding intact.
+
+---
+
+## 7. Plan
+
+1. **Review this doc** — semantics-reviewer (Design A + R16) and perf-architecture-reviewer (Design B: shapes, alloc, no-WeakMap, memo correctness).
+2. Run the **corpus differential** (mixin caller-read closed, 315 `.less` + `tests-error/eval` + jess, with negative control) to produce real blast-radius numbers; then owner settles R16 (scoped to mixin-call bodies) with that evidence. File detached-ruleset / value-lambda caller-read as a **separate** OPEN row. Correct the `Frame.fallback` doc comment.
+3. Implement B's pure-builder memo (frame-local `Map`) — safe today, unblocks D18.
+4. Implement A (closure-only variable resolution) once R16 is settled; update the 2 fixtures + legacy tests.
+5. Re-measure (12→~1 dispatch/index) + full core & jess suites; re-review the implementation (both reviewers).
+6. D18 (SCSS module access) builds on B (module = param-less anonymous mixin bound to `$ns`, member reads through the memoized pure path).

--- a/docs/design/MIXIN-SCOPING-AND-LOOKUP-MEMO.md
+++ b/docs/design/MIXIN-SCOPING-AND-LOOKUP-MEMO.md
@@ -16,7 +16,7 @@ Measured on the live engine (instrumented counters, 236f11674):
 - `@p: .mk-map(); .a { a: @p[one]; … f: @p[two]; }` — 6 member reads → **12** `declMapFromMixinCall` dispatches (2× per access). Each dispatch re-runs `expandCall(.mk-map)` — **true re-evaluation** of the mixin body per access.
 - `@m: { … }; .a { a: @m[one]; … }` — 5 reads → **10** `evalToDeclMap` rebuilds (2× per access) — re-indexing the body per access.
 
-So repeated member lookups are O(accesses) × O(body), not O(1) amortized. This is the same "don't re-derive what one pass already produced" principle as the extend rework (ledger X12).
+So repeated member lookups are O(accesses) × O(body), not O(1) amortized. This is the same repeated-re-derivation cost that ledger X12 (the extend rework) eliminated — recomputing what one pass already produced.
 
 Separately, the scoping question surfaced while designing the memo: a member lookup's result today can depend on the *call site's* variables (the leak), which both muddies the language rule and complicates any memo key.
 

--- a/packages/core/src/ast/__tests__/lookup-declmap-memo.test.ts
+++ b/packages/core/src/ast/__tests__/lookup-declmap-memo.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { parse as parseLess } from '../../../../syntax/less/less-parser/src/index.js';
+import { buildEvaluator } from '../evaluator.js';
+import { makeLessRegistry } from '@jesscss/fns';
+import { serialize } from '../serialize.js';
+
+/**
+ * [lookup-memo] Regression lock for the member-lookup DeclMap memo
+ * (`MIXIN-SCOPING-AND-LOOKUP-MEMO.md` §4). Repeated `BASE[member]` reads on a pure
+ * base (detached ruleset / collection / namespace selector) must return the correct
+ * member every time — the memo caches the INDEX, member values still resolve live —
+ * and output must be byte-identical whether the memo is on or off. If a future change
+ * lets the memo return a stale/wrong map, or breaks its transparency, this fails.
+ *
+ * The on/off transparency is asserted here structurally by pinning the output; the
+ * env knob `JESS_NO_DECLMAP_MEMO=1` reproduces the un-memoized path for a manual
+ * differential (the const is read at module load, so a same-process toggle is not
+ * meaningful — the pinned output below is the committed lock).
+ */
+const evaluator = buildEvaluator(makeLessRegistry());
+const render = (src: string): string =>
+  serialize(parseLess(src), { evaluator, collapseNesting: true }).css ?? '';
+
+describe('member-lookup DeclMap memo (correctness lock)', () => {
+  it('repeated reads of a detached-ruleset member resolve correctly each time', () => {
+    const src = '@m: { one: 1; two: 2; three: 3; };\n'
+      + '.a { a: @m[one]; b: @m[two]; c: @m[one]; d: @m[three]; e: @m[two]; }\n';
+    expect(render(src)).toBe('.a {\n  a: 1;\n  b: 2;\n  c: 1;\n  d: 3;\n  e: 2;\n}\n');
+  });
+
+  it('repeated reads through a chained accessor share the resolved base', () => {
+    // `@a: @m` then `@a[x]` and `@m[x]` resolve to the same pure base.
+    const src = '@m: { k: red; };\n@a: @m;\n.x { one: @a[k]; two: @m[k]; three: @a[k]; }\n';
+    expect(render(src)).toBe('.x {\n  one: red;\n  two: red;\n  three: red;\n}\n');
+  });
+
+  it('a member whose value references a sibling member still resolves live per read', () => {
+    // Guards that the memo caches the index, not evaluated values: `two` depends on `one`.
+    const src = '@m: { one: 2px; two: (@m[one] * 2); };\n'
+      + '.a { x: @m[two]; y: @m[one]; z: @m[two]; }\n';
+    expect(render(src)).toBe('.a {\n  x: 4px;\n  y: 2px;\n  z: 4px;\n}\n');
+  });
+});

--- a/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
+++ b/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
@@ -60,8 +60,11 @@ describe('V19 one-evaluator projection ratchet', () => {
   });
 
   it('does not grow the serializer helper or collection-construction surface', () => {
-    expect(occurrences(/^function |^async function /gmu)).toBe(430);
-    expect(occurrences(/new Map/gu)).toBe(58);
+    // +1 function (`memoPureDeclMap`) and +1 `new Map` (the lazy per-frame lookup memo,
+    // MIXIN-SCOPING-AND-LOOKUP-MEMO §4); `new WeakMap` stays 4 — the memo is a plain
+    // frame-owned Map, not a WeakMap, by design.
+    expect(occurrences(/^function |^async function /gmu)).toBe(431);
+    expect(occurrences(/new Map/gu)).toBe(59);
     expect(occurrences(/new Set/gu)).toBe(39);
     expect(occurrences(/new WeakMap/gu)).toBe(4);
     expect(occurrences(/const group: Leaf\[\] = \[\]/gu)).toBe(9);

--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -677,6 +677,21 @@ export interface Frame {
   propertyTimeline?: PropertyDeclarationFact[] | null;
 
   /*
+   * [lookup-memo] Render-scoped memo of member-lookup `DeclMap`s built for a PURE
+   * base resolved in THIS frame, keyed by the base value node identity. A repeated
+   * `BASE[member]` on the same binding rebuilt the index (or re-dispatched) per
+   * access; caching it on the resolving frame makes repeated reads O(1). Plain
+   * `Map` (not a WeakMap): the frame owns the lifetime and disposes it with the
+   * render; a node-keyed WeakMap would pin DeclMaps for the AST's whole cross-render
+   * lifetime. Assigned lazily only on a frame that performs a lookup, and populated
+   * ONLY for the pure builders (collection / namespace-selector / detached-ruleset
+   * body) — never a mixin-call dispatch (which mutates the caller frame) nor while an
+   * alias cycle is being resolved (`e.excluded` non-empty). See
+   * `docs/design/MIXIN-SCOPING-AND-LOOKUP-MEMO.md` §4.
+   */
+  declMapMemo?: Map<object, DeclMap> | null;
+
+  /*
    * [plugin/P1] functions registered by a `@plugin` (or, later, `@use`) directive
    * textually inside THIS frame's block, keyed lower-case like the global registry.
    * `null`/absent on EVERY frame unless this exact block loaded a scoped function
@@ -4640,6 +4655,37 @@ function recordMapPropertyTimeline(statements: readonly Statement[], frame: Fram
 }
 
 /** Resolve a map/namespace accessor's base to a declaration map + its frame. */
+/*
+ * [lookup-memo] Negative control: `JESS_NO_DECLMAP_MEMO=1` disables the member-lookup
+ * DeclMap memo so a measurement can reproduce the un-memoized rebuild/dispatch counts.
+ */
+const DECLMAP_MEMO_ENABLED = typeof process === 'undefined' || process.env?.JESS_NO_DECLMAP_MEMO !== '1';
+
+/**
+ * [lookup-memo] Cache a PURE base's DeclMap on the resolving frame, keyed by the base
+ * node identity, so a repeated `BASE[member]` on the same binding does not rebuild the
+ * index per access. Applied ONLY to the pure builders (collection / namespace-selector /
+ * detached-ruleset body) — never a mixin-call dispatch, which mutates the caller frame.
+ * Stores only when no alias cycle is being resolved (`e.excluded` empty), so a computed
+ * key that referenced an actively-excluded alias is never cached, and never caches a
+ * `null` (a not-yet-published base may resolve later). See
+ * `docs/design/MIXIN-SCOPING-AND-LOOKUP-MEMO.md` §4.
+ */
+function memoPureDeclMap(base: object, frame: Frame | null, e: EvalCtx, build: () => DeclMap | null): DeclMap | null {
+  if (!DECLMAP_MEMO_ENABLED || !frame) {
+    return build();
+  }
+  const hit = frame.declMapMemo?.get(base);
+  if (hit) {
+    return hit;
+  }
+  const built = build();
+  if (built !== null && e.excluded.size === 0) {
+    (frame.declMapMemo ??= new Map()).set(base, built);
+  }
+  return built;
+}
+
 function resolveBaseDeclMap(
   base: Binding,
   frame: Frame | null,
@@ -4653,7 +4699,7 @@ function resolveBaseDeclMap(
     return resolved === null ? null : resolveBaseDeclMap(resolved.value, resolved.frame, e);
   }
   if (base.type === 'Collection') {
-    return collectionToDeclMap(base, frame, e);
+    return memoPureDeclMap(base, frame, e, () => collectionToDeclMap(base, frame, e));
   }
 
   /*
@@ -4671,19 +4717,21 @@ function resolveBaseDeclMap(
    * The base is an opaque selector fragment (`Any`) or a bare ident (`Keyword`).
    */
   if (base.type === 'Any' || base.type === 'Keyword') {
-    const sel = base.src;
-    for (let f = frame; f; f = f.parent) {
-      const rules = f.rulesets !== undefined || f.statements ? frameRulesets(f)?.get(sel) : undefined;
-      if (rules?.length) {
-        const bodyFrame: Frame = {
-          parent: f,
-          mixins: null,
-          declIndex: collectDeclIndex(rules.flatMap(r => r.rules)), cells: null, reassign: null
-        };
-        return evalToDeclMap(rules.flatMap(r => r.rules), bodyFrame, e);
+    return memoPureDeclMap(base, frame, e, () => {
+      const sel = base.src;
+      for (let f = frame; f; f = f.parent) {
+        const rules = f.rulesets !== undefined || f.statements ? frameRulesets(f)?.get(sel) : undefined;
+        if (rules?.length) {
+          const bodyFrame: Frame = {
+            parent: f,
+            mixins: null,
+            declIndex: collectDeclIndex(rules.flatMap(r => r.rules)), cells: null, reassign: null
+          };
+          return evalToDeclMap(rules.flatMap(r => r.rules), bodyFrame, e);
+        }
       }
-    }
-    return null;
+      return null;
+    });
   }
 
   /*
@@ -4695,12 +4743,14 @@ function resolveBaseDeclMap(
    */
   const rs = resolveForRuleset(base, frame, e);
   if (rs) {
-    const bodyFrame: Frame = {
-      parent: rs.frame,
-      mixins: collectMixins(rs.rules),
-      declIndex: collectDeclIndex(rs.rules), cells: null, reassign: null
-    };
-    return evalToDeclMap(rs.rules, bodyFrame, e);
+    return memoPureDeclMap(base, frame, e, () => {
+      const bodyFrame: Frame = {
+        parent: rs.frame,
+        mixins: collectMixins(rs.rules),
+        declIndex: collectDeclIndex(rs.rules), cells: null, reassign: null
+      };
+      return evalToDeclMap(rs.rules, bodyFrame, e);
+    });
   }
 
   /*


### PR DESCRIPTION
Repeated `BASE[member]` lookups rebuilt their member index per access (measured: a detached-ruleset map read 5× rebuilt the DeclMap 10×). This caches the DeclMap on the **resolving frame**, keyed by base-node identity, for the **pure** builders only — collection, namespace-selector, and detached-ruleset body (the `@use` module path too). Plain `Map`, not a WeakMap: the frame owns the lifetime and disposes it with the render.

Gated per-arm (never the `Reference`/`MixinCall` arms, which consult `e.excluded` or run `expandCall`); stored only when no alias cycle is active (`e.excluded` empty), so a computed key over an actively-excluded alias is never cached; never caches null. Negative control: `JESS_NO_DECLMAP_MEMO=1` reproduces the un-memoized path.

**Deliberately deferred:** the mixin-call dispatch (`@p:.mk()[x]`) is NOT memoized — it mutates the caller frame (`leakBodyVars`/publish), so memoizing it isn't observationally free. That's a second cut behind the mixin-scoping decision.

Reviewed by perf-architecture twice (design + implementation): per-arm gating, store guard, WeakMap-free per-render lifetime, and node+frame keying all confirmed correct; byte-transparent on/off. Committed correctness lock: `lookup-declmap-memo.test.ts` (passes identically with the memo on and off; a sibling-member-reference case proves the memo caches the index, not values). Full core + jess suites byte-identical; ratchet updated (+1 fn, +1 Map; `new WeakMap` unchanged at 4).

Design: `docs/design/MIXIN-SCOPING-AND-LOOKUP-MEMO.md`. Unblocks D18 (SCSS module member access) and is the general re-index fix; the caller-scope-leak close (R16) and the mixin-call second cut are tracked there for a later PR.