### PR TITLE
docs(core): flag @-use/@-from as an unwired stub (#182)

### DIFF
--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -15852,6 +15852,14 @@ function emitCssImportAtRule(node: StyleImport, frame: Frame, e: Emit): void {
   }
 }
 
+// ponytail: TODO(jesscss/jess#182) — this is a stub. `@-use`/`@-from` are
+// compile-time JS-module directives (the JS half of the `@use` target split;
+// styles go through `@compose`/`StyleImport`, which loads via importDocument).
+// They must be CONSUMED at eval — resolve the module, bind its exports, emit
+// nothing — not re-serialized into output CSS as this does. No loader/binder
+// for ModuleImport exists yet (never ported into AST-v2). The JS-module graph
+// is partially implemented in the `@plugin` less-compat plugin and could share
+// resolution (Deno). See #182 before wiring the real load/bind.
 function emitModuleImport(node: ModuleImport, frame: Frame, e: Emit): void {
   const start = e.off;
   if (e.depth > 0) {

--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -15852,14 +15852,16 @@ function emitCssImportAtRule(node: StyleImport, frame: Frame, e: Emit): void {
   }
 }
 
-// ponytail: TODO(jesscss/jess#182) — this is a stub. `@-use`/`@-from` are
-// compile-time JS-module directives (the JS half of the `@use` target split;
-// styles go through `@compose`/`StyleImport`, which loads via importDocument).
-// They must be CONSUMED at eval — resolve the module, bind its exports, emit
-// nothing — not re-serialized into output CSS as this does. No loader/binder
-// for ModuleImport exists yet (never ported into AST-v2). The JS-module graph
-// is partially implemented in the `@plugin` less-compat plugin and could share
-// resolution (Deno). See #182 before wiring the real load/bind.
+/*
+ * ponytail: TODO(jesscss/jess#182) — this is a stub. `@-use`/`@-from` are
+ * compile-time JS-module directives (the JS half of the `@use` target split;
+ * styles go through `@compose`/`StyleImport`, which loads via importDocument).
+ * They must be CONSUMED at eval — resolve the module, bind its exports, emit
+ * nothing — not re-serialized into output CSS as this does. No loader/binder
+ * for ModuleImport exists yet (never ported into AST-v2). The JS-module graph
+ * is partially implemented in the `@plugin` less-compat plugin and could share
+ * resolution (Deno). See #182 before wiring the real load/bind.
+ */
 function emitModuleImport(node: ModuleImport, frame: Frame, e: Emit): void {
   const start = e.off;
   if (e.depth > 0) {


### PR DESCRIPTION
Comment-only. Marks `emitModuleImport` as a stub: `@-use`/`@-from` (JS-module imports) are re-serialized into output instead of being consumed and bound at compile time. Full context and repro in #182.

No behavior change.