### PR TITLE
test(less): activate the dormant Less-parity suite (11 files)

### DIFF
--- a/packages/jess/test/less/colors.test.ts
+++ b/packages/jess/test/less/colors.test.ts
@@ -16,13 +16,13 @@ const colorCompiler = new Compiler({
   compile: {
     plugins: [
       lessPlugin({
-        mathMode: 0
+        mathMode: 'always'
       })
     ]
   }
 });
 
-describe.todo('Color Functions', () => {
+describe('Color Functions', () => {
   const colorFiles = glob.sync(path.join(testData, 'tests-unit/color-functions/*.less'));
 
   colorFiles

--- a/packages/jess/test/less/detached-ruleset-scope.test.ts
+++ b/packages/jess/test/less/detached-ruleset-scope.test.ts
@@ -22,7 +22,7 @@ const compiler = new Compiler({
   compile: { plugins: [lessPlugin(), lessCompatPlugin()] }
 });
 
-describe.todo('Detached ruleset variable scoping', () => {
+describe('Detached ruleset variable scoping', () => {
   it('accesses mixin parameter inside detached ruleset (inline)', async () => {
     const css = await compiler.renderString(`
       #hover(@content) {

--- a/packages/jess/test/less/expressions.test.ts
+++ b/packages/jess/test/less/expressions.test.ts
@@ -3,7 +3,7 @@ import { Compiler } from '../../src/index.js';
 import { Context } from '@jesscss/core';
 import lessPlugin from '@jesscss/plugin-less';
 
-describe.todo('Functions', () => {
+describe('Functions', () => {
   const compiler = new Compiler({
     output: { collapseNesting: true },
     compile: {
@@ -11,7 +11,7 @@ describe.todo('Functions', () => {
     }
   });
 
-  describe.todo('Expressions', () => {
+  describe('Expressions', () => {
     it('should handle parenthesis in expressions', async () => {
       const lessCode = `
         @var: 42;

--- a/packages/jess/test/less/functions.test.ts
+++ b/packages/jess/test/less/functions.test.ts
@@ -306,7 +306,7 @@ describe('Functions', () => {
     });
   });
 
-  describe.todo('Built-in Math Functions', () => {
+  describe('Built-in Math Functions', () => {
     it('should handle round function', async () => {
       const lessCode = `
         .test {
@@ -360,7 +360,7 @@ describe('Functions', () => {
     });
   });
 
-  describe.todo('Built-in String Functions', () => {
+  describe('Built-in String Functions', () => {
     it('should handle escape function', async () => {
       const lessCode = `
         .test {
@@ -384,7 +384,7 @@ describe('Functions', () => {
     });
   });
 
-  describe.todo('Built-in List Functions', () => {
+  describe('Built-in List Functions', () => {
     it('should handle length function', async () => {
       const lessCode = `
         .test {
@@ -740,7 +740,7 @@ describe('Functions', () => {
     });
   });
 
-  describe.todo('Built-in Type Functions', () => {
+  describe('Built-in Type Functions', () => {
     it('should handle isnumber function', async () => {
       const lessCode = `
         .test {
@@ -830,7 +830,7 @@ describe('Functions', () => {
     });
   });
 
-  describe.todo('Built-in Misc Functions', () => {
+  describe('Built-in Misc Functions', () => {
     it('should handle default function', async () => {
       const lessCode = `
         .test {
@@ -865,7 +865,7 @@ describe('Functions', () => {
     });
   });
 
-  describe.todo('Function with Variables', () => {
+  describe('Function with Variables', () => {
     it('should handle functions with variable parameters', async () => {
       const lessCode = `
         @color: #ff0000;
@@ -882,16 +882,16 @@ describe('Functions', () => {
 
     it('should handle functions with computed parameters', async () => {
       const lessCode = `
-        @base: 10;
+        @base: 10px;
         @multiplier: 2;
-        
+
         .test {
-          width: (@base * @multiplier)px;
+          width: (@base * @multiplier);
         }
       `;
 
       const css = await compiler.renderString(lessCode, { language: 'less' });
-      expect(css).toContain('width:');
+      expect(css).toContain('width: 20px');
     });
   });
 });

--- a/packages/jess/test/less/import-url.test.ts
+++ b/packages/jess/test/less/import-url.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Compiler } from '../../src/index.js';
 
-describe.todo('Import URL', () => {
+describe('Import URL', () => {
   const compiler = new Compiler();
 
   it('should handle @import url("file.less")', async () => {

--- a/packages/jess/test/less/interpolated-mixin-body.test.ts
+++ b/packages/jess/test/less/interpolated-mixin-body.test.ts
@@ -28,7 +28,7 @@ const compiler = new Compiler({
   }
 });
 
-describe.todo('Interpolated names in mixin bodies', () => {
+describe('Interpolated names in mixin bodies', () => {
   it('resolves interpolated selector from mixin variable', async () => {
     const css = await compiler.renderString(`
       #gen(@color) {

--- a/packages/jess/test/less/interpolated-names.test.ts
+++ b/packages/jess/test/less/interpolated-names.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { Compiler } from '../../src/index.js';
 
-describe.todo('Interpolated Names', () => {
+describe('Interpolated Names', () => {
   const compiler = new Compiler();
 
-  describe.todo('Declaration Names', () => {
+  describe('Declaration Names', () => {
     it('should handle interpolated declaration names', async () => {
       const lessCode = `
         @prefix: color;
@@ -34,7 +34,7 @@ describe.todo('Interpolated Names', () => {
     });
   });
 
-  describe.todo('Lookup', () => {
+  describe('Lookup', () => {
     it('should find declarations with interpolated names', async () => {
       const lessCode = `
         @type: primary;

--- a/packages/jess/test/less/mixins.test.ts
+++ b/packages/jess/test/less/mixins.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { Compiler } from '../../src/index.js';
 import lessPlugin from '@jesscss/plugin-less';
 
-describe.todo('Mixins', () => {
+describe('Mixins', () => {
   const compiler = new Compiler({
     output: {
       collapseNesting: true
@@ -12,7 +12,7 @@ describe.todo('Mixins', () => {
     }
   });
 
-  describe.todo('Basic Mixins', () => {
+  describe('Basic Mixins', () => {
     it('should handle simple mixin definition and usage', async () => {
       const lessCode = `
         .mixin() {
@@ -67,7 +67,7 @@ describe.todo('Mixins', () => {
     });
   });
 
-  describe.todo('Mixin Parameters', () => {
+  describe('Mixin Parameters', () => {
     it('should handle mixin with parameters', async () => {
       const lessCode = `
         .mixin(@color) {
@@ -148,7 +148,7 @@ describe.todo('Mixins', () => {
     });
   });
 
-  describe.todo('Mixin Guards', () => {
+  describe('Mixin Guards', () => {
     it('should handle mixin with when guard', async () => {
       const lessCode = `
         .mixin(@color) when (@color = red) {
@@ -206,7 +206,7 @@ describe.todo('Mixins', () => {
     });
   });
 
-  describe.todo('Mixin Pattern Matching', () => {
+  describe('Mixin Pattern Matching', () => {
     it('should handle mixin with pattern matching #1', async () => {
       const lessCode = `
         .mixin(@color, @size) when (@size > 10px) {
@@ -262,7 +262,7 @@ describe.todo('Mixins', () => {
     });
   });
 
-  describe.todo('Mixin with @arguments', () => {
+  describe('Mixin with @arguments', () => {
     it('should handle mixin with @arguments', async () => {
       const lessCode = `
         .mixin(@color, @size) {
@@ -283,7 +283,7 @@ describe.todo('Mixins', () => {
     });
   });
 
-  describe.todo('Recursive Mixins', () => {
+  describe('Recursive Mixins', () => {
     it('should handle recursive mixin calls without infinite loops', async () => {
       const lessCode = `
         .recursion() {

--- a/packages/jess/test/less/operations.test.ts
+++ b/packages/jess/test/less/operations.test.ts
@@ -9,7 +9,7 @@ import lessPlugin from '@jesscss/plugin-less';
  * (`appendBareSlashTokens`) and stopped folding, while a hex color still folded.
  * lessc 4.x `--math=always`: `red / 2` → `#800000` AND `#ff0000 / 2` → `#800000`
  * (symmetric). The font-shorthand slash-SPACING row from the surrounding
- * `describe.todo('Operations')` block is deliberately NOT un-todoed here: it
+ * `describe('Operations')` block is deliberately NOT un-todoed here: it
  * asserts the spaced separator form (`small / 20px`), which is the OPEN V12
  * question (authored-slash spacing), unimplemented and unrelated to this change.
  */
@@ -35,14 +35,14 @@ describe('Operations — named-color division in math: always', () => {
   });
 });
 
-describe.todo('Operations', () => {
+describe('Operations', () => {
   const compiler = new Compiler({
     compile: {
       plugins: [lessPlugin()]
     }
   });
 
-  describe.todo('Basic Arithmetic Operations', () => {
+  describe('Basic Arithmetic Operations', () => {
     it('should handle addition', async () => {
       const lessCode = `
         .test {
@@ -96,7 +96,7 @@ describe.todo('Operations', () => {
     });
   });
 
-  describe.todo('Operations with Variables', () => {
+  describe('Operations with Variables', () => {
     it('should handle operations with variables', async () => {
       const lessCode = `
         @base: 10px;
@@ -132,7 +132,12 @@ describe.todo('Operations', () => {
       const css = await compiler.renderString(lessCode, { language: 'less' });
       expect(css).toContain('width: 80px');
       expect(css).toContain('height: 60px');
-      expect(css).toContain('area: 5000px');
+
+      /*
+       * px * px composes a unit CSS cannot express: v5 warns and defers to calc()
+       * (Less 4.x naively produced `5000px`). Loose unitMode would multiply instead.
+       */
+      expect(css).toContain('area: calc(100px * 50px)');
     });
 
     it('preserves slash-list variable values inside later operations in parens-division mode', async () => {
@@ -218,7 +223,7 @@ describe.todo('Operations', () => {
     });
   });
 
-  describe.todo('Color Operations', () => {
+  describe('Color Operations', () => {
     it('should handle color arithmetic', async () => {
       const lessCode = `
         .test {
@@ -248,7 +253,7 @@ describe.todo('Operations', () => {
     });
   });
 
-  describe.todo('Unit Operations', () => {
+  describe('Unit Operations', () => {
     it('should handle operations with different units', async () => {
       const lessCode = `
         .test {
@@ -279,7 +284,7 @@ describe.todo('Operations', () => {
     });
   });
 
-  describe.todo('Parentheses and Precedence', () => {
+  describe('Parentheses and Precedence', () => {
     it('should handle parentheses for precedence', async () => {
       const lessCode = `
         .test {
@@ -307,7 +312,7 @@ describe.todo('Operations', () => {
     });
   });
 
-  describe.todo('calc() Function', () => {
+  describe('calc() Function', () => {
     it('should handle calc() function', async () => {
       const lessCode = `
         .test {
@@ -338,7 +343,7 @@ describe.todo('Operations', () => {
     });
   });
 
-  describe.todo('Edge Cases', () => {
+  describe('Edge Cases', () => {
     it('should handle operations with zero', async () => {
       const lessCode = `
         .test {

--- a/packages/jess/test/less/root-leak.test.ts
+++ b/packages/jess/test/less/root-leak.test.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-describe.todo(':root selector context leak', () => {
+describe(':root selector context leak', () => {
   const compiler = new Compiler({
     compile: {
       plugins: [lessPlugin()]

--- a/packages/jess/test/less/static-names.test.ts
+++ b/packages/jess/test/less/static-names.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { Compiler } from '../../src/index.js';
 
-describe.todo('Static Names', () => {
+describe('Static Names', () => {
   const compiler = new Compiler();
 
-  describe.todo('Declaration Names', () => {
+  describe('Declaration Names', () => {
     it('should handle static declaration names', async () => {
       const lessCode = `
         @color: red;
@@ -54,7 +54,7 @@ describe.todo('Static Names', () => {
     });
   });
 
-  describe.todo('Lookup', () => {
+  describe('Lookup', () => {
     it('should find static variable declarations', async () => {
       const lessCode = `
         @primary: blue;


### PR DESCRIPTION
Turns on the dormant `packages/jess/test/less` parity suite, established by running the whole thing against current output + the lessc 4.6.3 oracle.

**8 already-correct suites** — pure `describe.todo` → `describe` (52 tests), behavior already matches:
detached-ruleset-scope (9), interpolated-mixin-body (9), static-names (6), root-leak (5), interpolated-names (4), import-url (2), expressions (1), mixins (16).

**3 suites with stale 4.x expectations** — corrected to assert v5 behavior, then activated:
- colors: the test passed `mathMode: 0` — an invalid Less-3.x numeric (the option is a string enum), which broke parsing of modern CSS color syntax. With a valid `'always'`, all 3 color-function fixtures match the golden byte-for-byte.
- functions: replaced the dead `(@x * @y)px` early-Jess exploration (a trailing unit on a paren group — never Less) with valid Less.
- operations: `100px * 50px` composes a unit CSS cannot express — v5 warns and defers to `calc(100px * 50px)` rather than 4.x's naive `5000px`.

No source changes — parity-test activation + stale-expectation corrections only.

Still dormant, pending design/intent decisions (follow-ups): variables (`@foo: .a; @foo()` and `@{foo}` selector interpolation), property-accessors (computed lookup keys), nesting (escaped string in a media prelude); plus the deferred extend-chaining AST-introspection snapshots and the `@plugin` JS-ABI (#182).