### PR TITLE
fix(core): keep escaped strings verbatim in query preludes

### DIFF
--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -16375,6 +16375,17 @@ function evalQueryPrelude(node: ValueSlot, frame: Frame | null, e: EvalCtx): May
       }
       return evalQueryPrelude(resolved.value, resolved.frame, e);
     }
+    case 'Quoted':
+      /*
+       * Keep the `~"…"` / `~'…'` wrapper so `normalizeQueryPrelude` treats the
+       * value as an OPAQUE run and prints it verbatim — a ratio `~"2/1"` stays
+       * tight (`2/1`), not ` / `-spaced by the plain-run rules. `evalBytes`
+       * unwraps an escaped string to its inner bytes, which would drop the marker
+       * and expose the value to plain-run spacing. A plain quoted string already
+       * keeps its quotes through `evalBytes` (`node.src`), so only the escaped
+       * form needs re-wrapping here.
+       */
+      return node.escaped ? `~${node.quote}${node.value}${node.quote}` : evalBytes(node, frame, e);
     default:
       return evalBytes(node, frame, e);
   }

--- a/packages/jess/test/less/nesting.test.ts
+++ b/packages/jess/test/less/nesting.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { Compiler } from '../../src/index.js';
 import lessPlugin from '@jesscss/plugin-less';
 
-describe.todo('Nesting', () => {
+describe('Nesting', () => {
   const compiler = new Compiler({
     compile: {
       plugins: [lessPlugin()]
     }
   });
 
-  describe.todo('Some nesting test cases', () => {
+  describe('Some nesting test cases', () => {
     it('should handle nested selectors', async () => {
       const lessCode = `
         @media (-o-min-device-pixel-ratio: ~"2/1"), (min-resolution: 2dppx) {


### PR DESCRIPTION
`@media (-o-min-device-pixel-ratio: ~"2/1")` rendered `2 / 1` instead of `2/1`.

**Cause:** the escaped `~"…"` wrapper was unwrapped by the value emit *before* `normalizeQueryPrelude` ran, so the inner `2/1` landed in a plain run and hit the slash-spacing rule (intended for authored ratios like `16/9`). The normalizer already has escaped-string protection — it just never saw the wrapper.

**Fix:** `evalQueryPrelude` keeps the `~"…"` wrapper for escaped strings so the normalizer treats the value as an opaque run and prints it verbatim — matching declaration output and lessc 4.6.3.

Unchanged: authored ratios (`16/9` → `16 / 9`, the intended v5 slash-spacing), plain quoted strings, and escaped strings in declarations. Activates the dormant `nesting` parity suite.

Verified: core 3304 passed, jess less suite 662 passed (less-test-data corpus included), oracle-matched.