### PR TITLE
fix(core): arm dynamic extend for &:extend() in an imported mixin body

### DIFF
--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -9302,10 +9302,12 @@ function bodyMayPlanExtend(statements: readonly Statement[]): boolean {
       for (const child of statement.rules) {
         pending.push(child);
       }
-    } else if (statement.type === 'For') {
+    } else if (statement.type === 'For' || statement.type === 'MixinDefinition') {
       /*
-       * `$for`/`each()` bodies are the one dynamic placement form that must
-       * admit imported extend planning even before their iterable is evaluated.
+       * `$for`/`each()` AND mixin-definition bodies are dynamic placement forms
+       * that must admit imported extend planning before they execute — an imported
+       * mixin whose body carries `&:extend()` (e.g. Bootstrap's `#make-grid-columns()`
+       * grid columns) arms the walk-time dynamic recorder the same way a loop does.
        */
       for (const child of statement.rules) {
         pending.push(child);

--- a/packages/jess/test/less/extend-cross-import.test.ts
+++ b/packages/jess/test/less/extend-cross-import.test.ts
@@ -73,4 +73,18 @@ describe('extend across @import (output oracle vs less@4)', () => {
       ['.ext {', '  color: red;', '}', '.ext {', '  background: blue;', '}'].join('\n')
     );
   });
+
+  /*
+   * less@4 4.6.7 oracle:
+   *   .grid-column, .col-1, .col-2, .col-3 { color: red; }
+   * An IMPORTED mixin whose body carries `&:extend()` (Bootstrap's `#make-grid-columns()`
+   * grid-column shape) must arm walk-time dynamic extend recording — the imported
+   * extend-admission gate has to descend into MixinDefinition bodies, not just loops.
+   */
+  it('imported mixin-body &:extend() accumulates the extenders onto the target', async () => {
+    const css = await renderFile('main-mixin-extend.less');
+    expect(css).toBe(
+      ['.grid-column,', '.col-1,', '.col-2,', '.col-3 {', '  color: red;', '}'].join('\n')
+    );
+  });
 });

--- a/packages/jess/test/less/fixtures/extend-cross-import/imported-mixin-extend.less
+++ b/packages/jess/test/less/fixtures/extend-cross-import/imported-mixin-extend.less
@@ -1,0 +1,12 @@
+// An imported mixin whose body carries `&:extend()` in a (recursive) loop —
+// the Bootstrap `#make-grid-columns()` shape. The mixin is defined AND called here.
+.grid-column {
+  color: red;
+}
+#gen(@i: 1) when (@i <= 3) {
+  .col-@{i} {
+    &:extend(.grid-column);
+  }
+  #gen(@i + 1);
+}
+#gen();

--- a/packages/jess/test/less/fixtures/extend-cross-import/main-mixin-extend.less
+++ b/packages/jess/test/less/fixtures/extend-cross-import/main-mixin-extend.less
@@ -1,0 +1,1 @@
+@import "imported-mixin-extend.less";


### PR DESCRIPTION
**Bug:** `bodyMayPlanExtend` (the gate admitting an imported document to extend planning) recursed into `Ruleset`, `AtRuleBlock`, and `For` bodies but **not `MixinDefinition` bodies**. An imported mixin whose body carries `&:extend()` — e.g. Bootstrap's `#make-grid-columns()` (`.col-*{ &:extend(.grid-column) }`) — never armed walk-time dynamic extend recording, so the extenders were dropped: `.grid-column` rendered alone instead of `.grid-column, .col-1, .col-2, …`.

**Fix:** the gate now descends into `MixinDefinition` bodies too (one production covers `For` and `MixinDefinition`). The dynamic-extend machinery itself already handled this — for the main document and for loop bodies — so this is purely the imported-admission wiring, no duplicate handling.

Verified: new output test (imported mixin-body `&:extend()` accumulates), core 3304 passed, less suite 663, no regressions. bootstrap4's grid columns now render the full `.grid-column, .col-1, …` list; its remaining diffs are intended-v5 numeric precision (V4) to be reconciled separately.