### PR TITLE
fix(core): keep evaluated Color mixin args typed across the call boundary

### DIFF
--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -5586,7 +5586,14 @@ function valueGroupHasUrl(value: ValueGroup): boolean {
 /** Whether eager byte binding would erase structure needed by typed consumers. */
 function valueGroupNeedsMixinCarrier(value: ValueGroup): boolean {
   return isValueGroupArray(value) || value.type === 'Url' || value.type === 'List'
-    || value.type === 'Block' || value.type === 'Collection';
+    || value.type === 'Block' || value.type === 'Collection'
+
+    /*
+     * A Color produced by an evaluated arg (e.g. `rgba(0,0,0,.5)`) serializes to
+     * function-call bytes that no longer re-parse as a color literal, so a typed
+     * consumer in the body (`darken(@arg)`) needs the retained Color, not bytes.
+     */
+    || value.type === 'Color';
 }
 
 const MIXIN_GROUP_SCALAR = 0;

--- a/packages/jess/test/less/mixin-color-arg-typed.test.ts
+++ b/packages/jess/test/less/mixin-color-arg-typed.test.ts
@@ -1,0 +1,34 @@
+/**
+ * A Color produced by evaluating a mixin argument (`rgba(0,0,0,.5)`, or a variable
+ * chain ending in one) must reach the mixin body as a TYPED color, so a nested
+ * color function in the body (`darken`/`fade`/`lighten`) can operate on it.
+ *
+ * Regression: such args were snapshotted to eager bytes ("rgba(0, 0, 0, 0.5)")
+ * that no longer re-parse as a color literal, so the body's `darken(@arg)` was
+ * preserved verbatim instead of evaluating. Literal color/dimension args already
+ * bound by reference and were unaffected; only evaluated (function-call) colors
+ * lost their type. Oracle: lessc 4.x evaluates these fully.
+ */
+import { describe, it, expect } from 'vitest';
+import { Compiler } from '../../src/index.js';
+import lessPlugin from '@jesscss/plugin-less';
+
+const compile = async (source: string): Promise<string> => {
+  const c = new Compiler({ output: { collapseNesting: true }, compile: { plugins: [lessPlugin()] } });
+  return (await c.renderToResult({ source, language: 'less', extension: '.less' }, {})).css.trim();
+};
+
+describe('evaluated color mixin-arg stays typed across the call boundary', () => {
+  it('darken of a literal rgba arg evaluates', async () => {
+    const css = await compile('#v(@bg) { c: darken(@bg, 5%); }\n.a { #v(rgba(0,0,0,0.5)); }');
+    expect(css).toBe('.a {\n  c: rgba(0, 0, 0, 0.5);\n}');
+  });
+  it('darken of a variable-chain rgba arg evaluates', async () => {
+    const css = await compile('@thb: rgba(0,0,0,0.5);\n#v(@bg) { c: darken(@bg, 5%); }\n.a { #v(@thb); }');
+    expect(css).toBe('.a {\n  c: rgba(0, 0, 0, 0.5);\n}');
+  });
+  it('fade visibly changes the alpha (typed processing, not passthrough)', async () => {
+    const css = await compile('#v(@bg) { c: fade(@bg, 20%); }\n.a { #v(rgba(255,0,0,0.5)); }');
+    expect(css).toBe('.a {\n  c: rgba(255, 0, 0, 0.2);\n}');
+  });
+});


### PR DESCRIPTION
## What

A mixin argument that *evaluates* to a color — `rgba(0,0,0,.5)`, or a variable chain ending in one — reached the mixin body as opaque bytes instead of a typed `Color`. A nested color function in the body then couldn't process it:

```less
#v(@bg) { c: darken(@bg, 5%); }
.a { #v(rgba(0,0,0,0.5)); }
```

**Before:** `.a { c: darken(rgba(0, 0, 0, 0.5), 5%); }` (preserved verbatim)
**After / lessc 4.x:** `.a { c: rgba(0, 0, 0, 0.5); }`

## Why

Evaluated (function-call) args are snapshotted to eager bytes at the call boundary; the typed structure is retained beside them only when the bytes would erase it (`Url`/`List`/`Block`/`Collection`). A `Color` was treated as byte-round-trippable, but an evaluated color with alpha serializes to `rgba(...)` function-call bytes that no longer re-parse as a color literal — so the body's `darken(@arg)` got an opaque `Any` and preserved the call.

Literal color and dimension args were unaffected: they bind **by reference**, so their type already survived. Only function-call-produced colors lost it. `Dimension` bytes (`5px`) do round-trip, so they weren't affected either.

## Fix

One clause: retain the typed carrier for `Color` in `valueGroupNeedsMixinCarrier`, exactly as for the existing structure-erasing types.

## Tests

- New `packages/jess/test/less/mixin-color-arg-typed.test.ts` — `darken` of literal + variable-chain rgba args, and `fade` (asserts the alpha visibly changes 0.5 → 0.2, proving typed processing rather than passthrough).
- Full core suite (3304) and jess Less suite (666) green; projection ratchet unchanged.

This was surfaced while reconciling the bootstrap4 fixture (its theme mixins pass `rgba`/theme colors into `darken`/`fade`).