### PR TITLE
fix(less-parser): keep a quoted lone operator char as a string, not a bare operator

### DIFF
--- a/packages/jess/test/less/quoted-slash-value.test.ts
+++ b/packages/jess/test/less/quoted-slash-value.test.ts
@@ -1,0 +1,34 @@
+/**
+ * A quoted string whose body is exactly a bare operator char (`"/"`, `'-'`, `"%"`)
+ * must stay a quoted string, not collapse to the bare slash/sign/percent operator.
+ *
+ * Regression: `isLessTerminalText` matched any object with a string `.value`, and a
+ * `Quoted` AST node carries `value: "/"`, so a standalone `"/"` was rewritten to a
+ * `Keyword '/'` in the value reducer — Bootstrap's breadcrumb divider
+ * (`@breadcrumb-divider: "/"; content: @breadcrumb-divider;`) emitted the invalid
+ * `content: /`. Only a lone operator char was affected; `"//"`, `"a/b"` were fine.
+ * Oracle: lessc 4.x emits `content: "/"`.
+ */
+import { describe, it, expect } from 'vitest';
+import { Compiler } from '../../src/index.js';
+import lessPlugin from '@jesscss/plugin-less';
+
+const compile = async (source: string): Promise<string> => {
+  const c = new Compiler({ output: { collapseNesting: true }, compile: { plugins: [lessPlugin()] } });
+  return (await c.renderToResult({ source, language: 'less', extension: '.less' }, {})).css.trim();
+};
+
+describe('quoted lone-operator strings keep their quotes', () => {
+  it('literal content: "/"', async () => {
+    expect(await compile('.a::before { content: "/"; }')).toBe('.a::before {\n  content: "/";\n}');
+  });
+  it('breadcrumb-style variable divider', async () => {
+    expect(await compile('@d: "/";\n.a::before { content: @d; }')).toBe('.a::before {\n  content: "/";\n}');
+  });
+  it('single-quoted and other operator chars survive', async () => {
+    expect(await compile(`.a { x: '/'; y: "-"; z: "%"; }`)).toBe(`.a {\n  x: '/';\n  y: "-";\n  z: "%";\n}`);
+  });
+  it('bare slash still forms the font shorthand', async () => {
+    expect(await compile('.a { font: 12px/1.5 sans-serif; }')).toBe('.a {\n  font: 12px/1.5 sans-serif;\n}');
+  });
+});

--- a/packages/syntax/less/less-parser/src/grammar-helpers.ts
+++ b/packages/syntax/less/less-parser/src/grammar-helpers.ts
@@ -218,8 +218,14 @@ function requireCombinator(value: unknown): SelectorCombinator {
 }
 
 function isLessTerminalText(value: unknown, text: string): boolean {
+  /*
+   * A raw grammar terminal is a string or a `{ value }` token; an AST value
+   * node also carries a string `value` (a `Quoted` body is the notable one), so
+   * excluding anything with a `type` field keeps a quoted `"/"`/`"-"`/`"%"` from
+   * being mistaken for the bare slash/sign/percent operator terminal.
+   */
   return (typeof value === 'string' && value === text)
-    || (typeof value === 'object' && value !== null && 'value' in value && value.value === text);
+    || (typeof value === 'object' && value !== null && !('type' in value) && 'value' in value && value.value === text);
 }
 
 function requireField(fields: FieldMap | undefined, name: string): FieldCapture {


### PR DESCRIPTION
## What

A quoted string whose body is exactly a bare operator char lost its quotes and came out as the operator:

```less
.breadcrumb-item + .breadcrumb-item::before { content: "/"; }
```

**Before:** `content: /;` (invalid — wrong node too: a `Keyword '/'`, not a `Quoted`)
**After / lessc 4.x:** `content: "/";`

Only an exact lone operator char was affected — `"/"`, `'/'`, `"-"`, `"%"`. `"//"`, `"a/b"`, `"/x"` and the real bare-slash operator (`font: 12px/1.5`) were all fine.

## Why

Recognition was correct — the CST parsed `"/"` as a proper string. The bug was in CST→AST lowering: `isLessTerminalText(child, '/')` in the value-piece reducer matched **any** object with a string `value` field, and a `Quoted` AST node carries `value: "/"`. So a standalone `"/"` was treated as the bare slash terminal (meant for the `literal('/')` value-piece fallback) and rewritten to `keyword('/')`. `"//"` survived only because its `value` (`//`) didn't equal `/`.

## Fix

Exclude AST nodes from the terminal-text check: a raw grammar terminal is a string or a `{ value }` token and never has a `type` field, whereas every AST value node does. One added `!('type' in value)` clause.

## Tests

- New `packages/jess/test/less/quoted-slash-value.test.ts` — literal + variable (breadcrumb-style) `content: "/"`, single-quoted / `"-"` / `"%"`, and a bare-slash `font` shorthand negative check.
- less-parser package suite (747, incl. the byte-identity oracle and the macro-fused compile) and the jess Less suite (670) both green.

Surfaced while reconciling the bootstrap4 fixture (breadcrumb divider).