### PR TITLE
fix(plugin-js): preserve a legacy @plugin colour's authored short form

### DIFF
--- a/packages/jess-plugin-js/src/bridge.ts
+++ b/packages/jess-plugin-js/src/bridge.ts
@@ -17,7 +17,7 @@ export type JsBridgeDeclaration = { name: string; value: JsBridgeValue };
 export type JsBridgeValue =
   | { __jessBridge: true; kind: 'scalar'; value: string | number | boolean }
   | { __jessBridge: true; kind: 'dimension'; value: number; unit?: string }
-  | { __jessBridge: true; kind: 'color'; rgb: [number, number, number]; alpha?: number }
+  | { __jessBridge: true; kind: 'color'; rgb: [number, number, number]; alpha?: number; bytes?: string }
   | { __jessBridge: true; kind: 'quoted'; value: string; quote?: '"' | '\''; escaped?: boolean }
   | { __jessBridge: true; kind: 'anonymous'; value: string }
   | { __jessBridge: true; kind: 'list'; items: JsBridgeValue[]; separator: ',' | '/' | ';' }
@@ -73,7 +73,8 @@ function encodeFacadeValue(value: BridgeRecord): JsBridgeValue | undefined {
             __jessBridge: true,
             kind: 'color',
             rgb: [value.rgb[0], value.rgb[1], value.rgb[2]],
-            alpha: typeof value.alpha === 'number' ? value.alpha : undefined
+            alpha: typeof value.alpha === 'number' ? value.alpha : undefined,
+            bytes: typeof value.bytes === 'string' ? value.bytes : undefined
           }
         : undefined;
     case 'Quoted':
@@ -126,7 +127,7 @@ export function encodeBridgeValue(value: unknown): unknown {
   if (isValueNode(value)) {
     switch (value.type) {
       case 'Dimension': return { __jessBridge: true, kind: 'dimension', value: value.number, unit: value.unit } satisfies JsBridgeValue;
-      case 'Color': return { __jessBridge: true, kind: 'color', rgb: [value.rgb[0], value.rgb[1], value.rgb[2]], alpha: value.alpha } satisfies JsBridgeValue;
+      case 'Color': return { __jessBridge: true, kind: 'color', rgb: [value.rgb[0], value.rgb[1], value.rgb[2]], alpha: value.alpha, bytes: value.bytes } satisfies JsBridgeValue;
       case 'Quoted': return { __jessBridge: true, kind: 'quoted', value: value.value, quote: value.quote === '\'' ? '\'' : '"', escaped: value.escaped } satisfies JsBridgeValue;
       case 'List':
         return value.sep === ',' || value.sep === '/'
@@ -157,11 +158,16 @@ function decodeValue(value: JsBridgeValue): ValueGroup {
     case 'dimension': return makeDimension(value.value, value.unit ?? '');
 
     /*
-     * less.js renders a plugin-built colour as hex (`#b8daff`), not `rgb(...)`;
-     * matching that keeps the bytes Less-shaped and keeps the value sniffable as
-     * a colour when it later travels through a byte lane.
+     * A colour that crosses the bridge unmodified (a looked-up `@white: #fff`
+     * returned by `color-yiq`) keeps its authored bytes so the short form
+     * survives, exactly as less.js preserves a passed-through colour's spelling.
+     * A colour the plugin BUILDS or COMPUTES carries its own serialized bytes
+     * too (a 6-digit hex from `makeColorRgb`), so this one path matches less.js
+     * for both. `makeColorRgb` stays the fallback for a pre-`bytes` wire value.
      */
-    case 'color': return makeColorRgb(value.rgb, value.alpha ?? 1, HEX);
+    case 'color': return value.bytes !== undefined
+      ? sniffLiteral(value.bytes)
+      : makeColorRgb(value.rgb, value.alpha ?? 1, HEX);
     case 'quoted': return makeQuoted(value.value, value.quote ?? '"', value.escaped === true);
 
     /*

--- a/packages/jess-plugin-js/src/runtime-worker.ts
+++ b/packages/jess-plugin-js/src/runtime-worker.ts
@@ -194,9 +194,15 @@ class Color extends Node {
    * less.js accepts an RGB triple OR a hex string WITHOUT the leading `#`
    * (`new tree.Color(someColor.toCSS().substr(1))`), which is precisely the
    * form bootstrap's `theme-color-level` plugin round-trips through.
+   *
+   * `originalForm` is the authored spelling of a colour that crossed the bridge
+   * unmodified (`@white: #fff`), mirroring less.js's Color `value`/originalForm:
+   * a pass-through keeps its short form, while a plugin-CONSTRUCTED colour has
+   * none and serialises to 6-digit hex.
    */
-  constructor(rgb, alpha = 1) {
+  constructor(rgb, alpha = 1, originalForm) {
     super();
+    this.originalForm = typeof originalForm === 'string' ? originalForm : undefined;
     if (Array.isArray(rgb)) {
       this.rgb = rgb.slice(0, 3).map(clampByte);
       this.alpha = typeof alpha === 'number' ? alpha : 1;
@@ -222,6 +228,9 @@ class Color extends Node {
 
   /** less.js renders an opaque colour as hex and a translucent one as `rgba()`. */
   toCSS() {
+    if (this.originalForm !== undefined) {
+      return this.originalForm;
+    }
     const [r, g, b] = this.rgb;
     return this.alpha === 1
       ? `#${hexPair(r)}${hexPair(g)}${hexPair(b)}`
@@ -621,7 +630,7 @@ const decodeBridgeValue = (value) => {
     case 'dimension':
       return new Dimension(value.value, value.unit ?? '');
     case 'color':
-      return new Color(value.rgb, value.alpha ?? 1);
+      return new Color(value.rgb, value.alpha ?? 1, value.bytes);
     case 'quoted':
       return new Quoted(value.quote ?? '"', value.value, value.escaped === true);
     case 'anonymous':
@@ -677,7 +686,8 @@ const encodeBridgeValue = (value) => {
       __jessBridge: true,
       kind: 'color',
       rgb: value.rgb,
-      alpha: value.alpha
+      alpha: value.alpha,
+      bytes: value.originalForm
     };
   }
   if (value instanceof Quoted) {

--- a/packages/jess/test/less/compat-color-shortform.test.ts
+++ b/packages/jess/test/less/compat-color-shortform.test.ts
@@ -1,0 +1,30 @@
+/**
+ * A colour that passes UNMODIFIED through a legacy `@plugin` JS function must keep
+ * its authored short-form spelling (`#fff`), matching lessc 4.x. Bootstrap 4's
+ * `color-yiq` looks up `@yiq-text-light` (= `@white` = `#fff`) and returns it; the
+ * value crosses the host <-> Deno-worker bridge, which previously rebuilt the colour
+ * from its numeric rgb channels and emitted 6-digit `#ffffff`.
+ *
+ * A colour the plugin CONSTRUCTS (`new tree.Color('fff')`) has no authored form and
+ * serialises to 6-digit hex — also matching lessc 4.x. Oracle: lessc 4.2.0 on this
+ * exact fixture emits `#fff` for the pass-through and `#ffffff` for the constructed.
+ */
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { Compiler } from '../../src/index.js';
+import lessPlugin from '@jesscss/plugin-less';
+import jsPlugin from '@jesscss/plugin-js';
+import { lessCompatPlugin } from '@jesscss/plugin-less-compat';
+
+const fixtures = path.join(__dirname, 'fixtures', 'compat-color');
+
+describe('legacy @plugin colour round-trip preserves authored short form', () => {
+  it('pass-through colour keeps #fff; constructed colour is 6-digit', async () => {
+    const c = new Compiler({
+      output: { collapseNesting: true },
+      compile: { jsReadRoot: fixtures, plugins: [lessPlugin(), jsPlugin({ jsReadRoot: fixtures, runtimeApi: 'less' }), lessCompatPlugin()] }
+    });
+    const css = (await c.render(path.join(fixtures, 'main.less'), { suppressWarnings: true, breakOnError: false })).trim();
+    expect(css).toBe('.passthrough {\n  color: #fff;\n}\n.constructed {\n  color: #ffffff;\n}');
+  });
+});

--- a/packages/jess/test/less/fixtures/compat-color/color-shortform.js
+++ b/packages/jess/test/less/fixtures/compat-color/color-shortform.js
@@ -1,0 +1,19 @@
+/* Minimal color-yiq-shaped legacy @plugin: returns a looked-up color variable
+   unmodified, plus a plugin-constructed color, to pin the compat color round-trip. */
+function lookupVariable(context, name) {
+  return tree.Variable.prototype.find(context.frames, (frame) => {
+    const hit = frame.variable(name);
+    if (!hit || hit.value === undefined) {
+      return undefined;
+    }
+    return hit.value.eval(context);
+  });
+}
+
+functions.add('passthrough-color', function() {
+  return lookupVariable(this.context, '@brand');
+});
+
+functions.add('constructed-color', function() {
+  return new tree.Color('fff');
+});

--- a/packages/jess/test/less/fixtures/compat-color/main.less
+++ b/packages/jess/test/less/fixtures/compat-color/main.less
@@ -1,0 +1,4 @@
+@plugin "color-shortform";
+@brand: #fff;
+.passthrough { color: passthrough-color(); }
+.constructed { color: constructed-color(); }

--- a/packages/syntax/less/jess-plugin-less-compat/src/less-api-bridge.ts
+++ b/packages/syntax/less/jess-plugin-less-compat/src/less-api-bridge.ts
@@ -255,7 +255,7 @@ export function toNativeLessValue(value: PluginRawArgument | ValueGroup): unknow
   switch (value.type) {
     case 'Dimension': return new LessDimension(value.number, value.unit);
     case 'Quoted': return new LessQuoted(value.quote, value.value, value.escaped);
-    case 'Color': return { type: 'Color', rgb: value.rgb, alpha: value.alpha, valueOf: () => value.bytes };
+    case 'Color': return { type: 'Color', rgb: value.rgb, alpha: value.alpha, bytes: value.bytes, valueOf: () => value.bytes };
     case 'List':
       return value.sep === ',' || value.sep === '/'
         ? new LazyValueList(value)


### PR DESCRIPTION
## What

A colour that passes **unmodified** through a legacy `@plugin` JS function lost its authored short-form spelling:

```less
@plugin "color-yiq";  // returns @yiq-text-light (= @white = #fff), unchanged
.btn-primary { color: color-yiq(@primary); }
```

**Before:** `color: #ffffff;`
**After / lessc 4.x:** `color: #fff;`

## Why

The @plugin JS runs in a Deno worker; values cross the host↔worker bridge as facts. A `color` fact carried only the numeric `rgb` channels, so both the worker's `tree.Color` and the host decoder rebuilt the colour as 6-digit hex, dropping the authored form. (jess's own pipeline already preserves `#fff`; only the legacy `@plugin` round-trip canonicalised.)

## Fix

Thread the colour's authored `bytes` through the entire round-trip:
- the wire `color` fact gains an optional `bytes` (`bridge.ts` + the worker's own encode/decode in `runtime-worker.ts`);
- the worker `Color` gains an `originalForm` that `toCSS()` returns when present — mirroring less.js's Color `value`/originalForm;
- `toNativeLessValue` (less-compat) exposes `bytes` as a real string field for the facade encoder.

A plugin-**constructed** colour (`new tree.Color('fff')`) has no authored form and still serialises to 6-digit hex — also matching lessc 4.x.

## Oracle

lessc **4.2.0** on the fixture emits `#fff` (pass-through) and `#ffffff` (constructed) — jess now matches byte-for-byte.

## Tests

- New `packages/jess/test/less/compat-color-shortform.test.ts` (+ fixture) — asserts both cases.
- Gates green: jess Less suite (671), `@jesscss/plugin-js` (16), `@jesscss/plugin-less-compat` (7). No `as any`/`@ts-ignore`.

This was the last remaining real diff in the bootstrap4 fixture (its theme colours flow through `color-yiq`); everything else there is intended v5 divergence (numeric precision, `:is()` compaction).