### PR TITLE
fix(less-parser): treat a whitespace-led sign on a variable/paren as a space-list item

### DIFF
--- a/packages/jess/test/less/negative-variable-space-list.test.ts
+++ b/packages/jess/test/less/negative-variable-space-list.test.ts
@@ -1,0 +1,40 @@
+/**
+ * A `-`/`+` with whitespace before it and glued to a variable or paren
+ * (`-@p`, `-(@p)`) is a leading SIGN on a new space-list item, exactly as
+ * `1 -2` is for a glued digit — NOT subtraction. Bootstrap's negative margins
+ * (`margin: -@y -@x -@y auto`) depend on this.
+ *
+ * Regression: the sum-operator sign policy exempted only ` -<digit>`; ` -@p`
+ * fell through as subtraction, so `-@p -@p -@p auto` summed to `-3rem auto`.
+ * Oracle: lessc 4.x keeps them as a space list.
+ */
+import { describe, it, expect } from 'vitest';
+import { Compiler } from '../../src/index.js';
+import lessPlugin from '@jesscss/plugin-less';
+
+const compile = async (source: string): Promise<string> => {
+  const c = new Compiler({ output: { collapseNesting: true }, compile: { plugins: [lessPlugin()] } });
+  return (await c.renderToResult({ source, language: 'less', extension: '.less' }, {})).css.trim();
+};
+
+describe('a whitespace-led sign on a variable is a space-list item, not subtraction', () => {
+  it('four-value negative-variable margin stays a space list', async () => {
+    expect(await compile('@p: 1rem;\n.a { margin: -@p -@p -@p auto; }'))
+      .toBe('.a {\n  margin: -1rem -1rem -1rem auto;\n}');
+  });
+  it('two negated variables stay a space list', async () => {
+    expect(await compile('@p: 1rem;\n.a { margin: -@p -@p; }')).toBe('.a {\n  margin: -1rem -1rem;\n}');
+  });
+  it('negated parens stay a space list', async () => {
+    expect(await compile('@p: 1rem;\n.a { margin: -(@p) -(@p); }')).toBe('.a {\n  margin: -1rem -1rem;\n}');
+  });
+  it('literal negatives are unaffected', async () => {
+    expect(await compile('.a { margin: -1rem -1rem -1rem auto; }')).toBe('.a {\n  margin: -1rem -1rem -1rem auto;\n}');
+  });
+  it('spaced subtraction still subtracts', async () => {
+    expect(await compile('@p: 5rem;\n.a { x: (@p - @p); }')).toBe('.a {\n  x: 0rem;\n}');
+  });
+  it('mixed literal and negated variable is a space list', async () => {
+    expect(await compile('@p: 2rem;\n.a { x: 1rem -@p; }')).toBe('.a {\n  x: 1rem -2rem;\n}');
+  });
+});

--- a/packages/syntax/less/less-parser/src/grammar.ts
+++ b/packages/syntax/less/less-parser/src/grammar.ts
@@ -640,7 +640,7 @@ const preservedSlashBoundary = leaf(
  * sign — so `lessFoldOperation` still reads an alternating operand/operator
  * stream and no CST arity moves.
  */
-const sumOperatorChar = noTrivia(regex(/[-+](?![0-9.])|(?<![ \t\n\r\f])[-+](?=[0-9.])/));
+const sumOperatorChar = noTrivia(regex(/[-+](?![0-9.@(])|(?<![ \t\n\r\f])[-+](?=[0-9.@(])/));
 const sumOperator = leaf(
   noTrivia(sequence(optional(mathTrivia), sumOperatorChar, optional(mathTrivia))),
   children => children[1] as string


### PR DESCRIPTION
## What

A negative-variable space list was being **summed** as subtraction:

```less
@p: 1rem;
.a { margin: -@p -@p -@p auto; }
```

**Before:** `margin: -3rem auto;` (summed `-1rem - 1rem - 1rem`)
**After / lessc 4.x:** `margin: -1rem -1rem -1rem auto;`

## Why

The sum-operator sign policy (`sumOperatorChar`) already treats ` -<digit>` as a leading sign, not an operator — that's why `1 -2` and literal `-1rem -1rem` are space lists. But the first arm `[-+](?![0-9.])` matched a `-`/`+` glued to a variable or paren (` -@p`, ` -(@p)`) **regardless of preceding whitespace**, so it became binary subtraction.

## Fix

Extend the same sign policy to `@` and `(`: a `-`/`+` glued to a digit, `@`, or `(` is a binary operator only when **not** preceded by whitespace; with whitespace before, it's a leading sign on a new space-list item.

```
/[-+](?![0-9.])       | (?<![ws])[-+](?=[0-9.])/       →
/[-+](?![0-9.@(])     | (?<![ws])[-+](?=[0-9.@(])/
```

Spaced subtraction (`@p - @p` → `0rem`), glued subtraction (`a-@p`), and literal negatives are all unchanged.

## Tests

- New `packages/jess/test/less/negative-variable-space-list.test.ts` (6 cases incl. the subtraction-still-works and literal-unchanged guards).
- less-parser suite (747, incl. the byte-identity oracle and operator-adjacency/comment-boundary tests) and jess Less suite (677) green.

Surfaced while reconciling the bootstrap4 golden — its `.modal-header .close { margin: -@modal-header-padding-y -@modal-header-padding-x … }` was the tell.