### PR TITLE
test(less): graduate variables.less off the expected-failure list

### DIFF
--- a/packages/jess/test/less/all-less.test.ts
+++ b/packages/jess/test/less/all-less.test.ts
@@ -314,10 +314,6 @@ const expectedFailureFixtures = new Map<string, string>([
     'OPEN F7(a): property-name interpolation renders byte-identically except that repeated `@{p}@{p}` loses the `/* foo */` source layout carried inside each complex interpolated value; interpolation-splice layout preservation awaits an owner ruling'
   ],
   [
-    'tests-unit/variables/variables.less',
-    'NOT a jess bug: `(@onePixel / @onePixel)` = `1px / 1px` — jess emits `1` (units cancel), which is the v5 ruling (RESOLVED-SEMANTICS-AND-NAMING §"2px / 1px → 2 — units cancel"). The golden encodes stale lessc-4.x `1px` (keeps left unit). Graduates once the owner v5 golden is updated to `1`'
-  ],
-  [
     'tests-unit/plugin-module/plugin-module.less',
     'the clean-css fixture uses a legacy CommonJS @plugin graph with require(\'./lib/clean\'), which the optional jess-plugin-js Deno compatibility runtime does not support'
   ],


### PR DESCRIPTION
The v5 corpus golden already carries the units-cancel values (`same-unit-as-previously: 1`, `odd-unit: 2`; `square-pixel-divided` stays `1px` because px·px/px = px), so jess renders `tests-unit/variables/variables.less` byte-identically to the golden. The stale "golden encodes 4.x `1px`" note is obsolete — remove the expected-failure marker so it runs as a real pass.

No corpus change needed (the golden is already v5); this is a jess-side cleanup. CI (which reads the fork-alpha corpus) is the definitive check.