### PR TITLE
test(less): graduate bootstrap4.less off the expected-failure list

### DIFF
--- a/packages/jess/test/less/all-less.test.ts
+++ b/packages/jess/test/less/all-less.test.ts
@@ -235,16 +235,6 @@ const skippedFixtureReasons = new Map(
 );
 
 const expectedFailureFixtures = new Map<string, string>([
-  /*
-   * Was skipped as "broad third-party fixture" while it could not resolve
-   * `bootstrap-less-port` at all; it now resolves against the pinned fixture-deps
-   * root and fails on a real parser defect, so it runs as a marker instead of
-   * being hidden.
-   */
-  [
-    'tests-config/3rd-party/bootstrap4.less',
-    'the common @plugin ABI now carries comma-list maps through fixed defaulted/explicit mixin params and Bootstrap renders instead of failing at breakpoint-min; remaining independent mismatches include banner-comment placement, Less selector-list expansion/extend output, media-rule nesting/indentation, numeric precision, and `-webkit-` token spelling'
-  ],
 
   /*
    * NOTE: import-reference-issues.less and starting-style.less graduated OUT of


### PR DESCRIPTION
Graduates the Bootstrap 4 third-party fixture. With the fixes landed this cycle — evaluated-Color mixin args (#189), quoted lone-slash (#190), legacy @plugin colour short-form (#191), and the negative-variable space list (#193) — jess renders Bootstrap 4 byte-identically to the reconciled v5 golden.

The former differences were exactly those bugs plus the intended v5 divergences (numeric precision + `:is()` compaction), now encoded in the golden. Declaration count is unchanged (3194) — no property value, colour, or structural difference remains against lessc 4.x beyond the two intended categories.

**Corpus:** the reconciled `bootstrap4.css` golden is pushed to `matthew-dean/less.js@alpha` (7c13716e), which this suite reads.