### PR TITLE
feat(core): generate source maps in the AST-v2 render path

### DIFF
--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -19,8 +19,10 @@ import {
   type ErrorsConfigInput,
   serialize,
   prepareStaticImports,
+  buildAstSourceMap,
   type PreparedImports,
-  type PluginInterface
+  type PluginInterface,
+  type Position
 } from '@jesscss/core';
 import type { Stylesheet } from '@jesscss/core/ast';
 import {
@@ -106,6 +108,62 @@ function internalUnknownDiagnostic(
     column: frame?.column ?? 1,
     lines: frame?.lines
   };
+}
+
+/** The normalized object form of the `output.sourceMap` option. */
+type SourceMapConfig = Exclude<NonNullable<OutputOptions['sourceMap']>, boolean>;
+
+/** The generated CSS plus, when source maps are on, the v3 map and its URL. */
+export interface RenderedStylesheet {
+  css: string;
+
+  /** v3 source map JSON (external form), when source maps are enabled. */
+  map?: string;
+
+  /** The `sourceMappingURL` written into the CSS annotation, when one is written. */
+  sourceMapURL?: string;
+}
+
+/**
+ * Assemble the source map + CSS annotation from the render's position stream.
+ *
+ * Mirrors Less 4.x `SourceMapBuilder.getCSSAppendage`: an explicit
+ * `sourceMapURL` wins over `sourceMapFilename`; `sourceMapFileInline` embeds the
+ * map as a base64 `data:` URI; `disableSourcemapAnnotation` writes nothing. The
+ * external `.map` string is always returned for callers that write it to disk —
+ * this compiler has no file-writing CLI, so that is a caller concern.
+ */
+function assembleSourceMap(
+  css: string,
+  positions: Position[],
+  option: SourceMapConfig,
+  outputFilePath: string | undefined
+): RenderedStylesheet {
+  const encoded = buildAstSourceMap(css, positions, {
+    /*
+     * The map's `file` is the GENERATED css filename (Less `_outputFilename`),
+     * not the `.map` filename.
+     */
+    outputFilename: option.sourceMapOutputFilename ?? outputFilePath ?? option.sourceMapFullFilename,
+    sourceMapRootpath: option.sourceMapRootpath,
+    sourceMapBasepath: option.sourceMapBasepath,
+    outputSourceFiles: option.outputSourceFiles
+  });
+  const map = JSON.stringify(encoded);
+
+  let sourceMapURL = option.sourceMapURL ?? option.sourceMapFilename;
+  let annotationURL = sourceMapURL;
+  if (option.sourceMapFileInline === true) {
+    annotationURL = `data:application/json;base64,${Buffer.from(map, 'utf8').toString('base64')}`;
+  }
+
+  let annotatedCss = css;
+  if (option.disableSourcemapAnnotation !== true && annotationURL) {
+    const newline = css.length > 0 && !css.endsWith('\n') ? '\n' : '';
+    annotatedCss = `${css}${newline}/*# sourceMappingURL=${annotationURL} */\n`;
+  }
+
+  return { css: annotatedCss, map, sourceMapURL: sourceMapURL ?? undefined };
 }
 
 /**
@@ -946,7 +1004,12 @@ export class Compiler {
       : null;
     contextOptions.output = {
       compress: cfgOutput?.compress,
-      sourceMap: typeof cfgOutput?.sourceMap === 'boolean' ? cfgOutput.sourceMap : Boolean(cfgOutput?.sourceMap),
+
+      /*
+       * Preserve the object form (sourceMapBasepath/rootpath/inline/…); coercing
+       * to a bool here would silently drop every source-map sub-option.
+       */
+      sourceMap: cfgOutput?.sourceMap,
       collapseNesting: resolved.printOptions.collapseNesting
     };
 
@@ -1081,8 +1144,11 @@ export class Compiler {
     document: Stylesheet,
     context: Context,
     profile?: RenderProfile,
-    preparedImports?: PreparedImports
-  ): Promise<string> {
+    preparedImports?: PreparedImports,
+    outputFilePath?: string
+  ): Promise<RenderedStylesheet> {
+    const sourceMapOption = context.opts.output?.sourceMap;
+    const trackPositions = Boolean(sourceMapOption);
     const result = await measureProfileAsync(profile, 'renderAstStylesheet', () =>
       Promise.resolve(context.withDocument(document, () => {
         this.activateDocumentPlugins(context);
@@ -1091,7 +1157,8 @@ export class Compiler {
           context,
           pluginHost: context.pluginHost,
           io: { readFile: specifier => readOptionalBinary(context, specifier) },
-          preparedImports
+          preparedImports,
+          trackPositions
         });
       })));
     let css = result.css;
@@ -1102,7 +1169,17 @@ export class Compiler {
         css = plugin.postProcessCss(css, context);
       }
     }
-    return css;
+    if (!trackPositions || result.positions === undefined) {
+      return { css };
+    }
+
+    /*
+     * ponytail: positions index into the serialized CSS; a postprocessor that
+     * rewrites `css` desyncs the map (same limitation as Less 4.x, whose map is
+     * also built pre-postprocess). Regenerate through postprocessors if needed.
+     */
+    const option: SourceMapConfig = typeof sourceMapOption === 'object' ? sourceMapOption : {};
+    return assembleSourceMap(css, result.positions, option, outputFilePath);
   }
 
   /** @internal AST document preparation; no legacy evaluator tree is exposed. */
@@ -1180,10 +1257,12 @@ export class Compiler {
     const { resolved, context, profile } = await this.prepareRender(filePath, options);
     try {
       const input = { filePath };
-      const css = await this.renderStylesheet(
+      const { css } = await this.renderStylesheet(
         await this.prepareStylesheet(context, resolved, input, profile),
         context,
-        profile
+        profile,
+        undefined,
+        resolved.resolvedOutputFilePath
       );
       context.finalizeWarnings();
       this.reportCollected(context, options);
@@ -1222,10 +1301,12 @@ export class Compiler {
 
     try {
       const input = { filePath, source: content, language, extension };
-      const css = await this.renderStylesheet(
+      const { css } = await this.renderStylesheet(
         await this.prepareStylesheet(context, resolved, input, profile),
         context,
-        profile
+        profile,
+        undefined,
+        resolved.resolvedOutputFilePath
       );
       context.finalizeWarnings();
       this.reportCollected(context, renderOptions);
@@ -1265,6 +1346,12 @@ export class Compiler {
     errors: ErrorDiagnostic[];
     warnings: WarningDiagnostic[];
     loadedUrls: string[];
+
+    /** v3 source map JSON, present only when source maps are enabled. */
+    map?: string;
+
+    /** The `sourceMappingURL` written into the CSS annotation, when one is written. */
+    sourceMapURL?: string;
   }> {
     const isSourceContent = typeof input === 'object' && 'source' in input;
     const source = isSourceContent ? input.source : undefined;
@@ -1276,10 +1363,12 @@ export class Compiler {
 
     try {
       const input = { filePath, source, language, extension };
-      const css = await this.renderStylesheet(
+      const { css, map, sourceMapURL } = await this.renderStylesheet(
         await this.prepareStylesheet(context, resolved, input, profile),
         context,
-        profile
+        profile,
+        undefined,
+        resolved.resolvedOutputFilePath
       );
 
       context.finalizeWarnings();
@@ -1296,7 +1385,9 @@ export class Compiler {
         css,
         errors: [...context.errors],
         warnings: [...context.warnings],
-        loadedUrls
+        loadedUrls,
+        ...(map === undefined ? {} : { map }),
+        ...(sourceMapURL === undefined ? {} : { sourceMapURL })
       };
     } catch (err: unknown) {
       const errors: ErrorDiagnostic[] = [...context.errors];
@@ -1415,10 +1506,12 @@ export class Compiler {
 
     try {
       const input = { filePath };
-      const css = await this.renderStylesheet(
+      const { css } = await this.renderStylesheet(
         await this.prepareStylesheet(context, resolved, input, profile),
         context,
-        profile
+        profile,
+        undefined,
+        resolved.resolvedOutputFilePath
       );
 
       finalizeRenderProfile(profile, {

--- a/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
+++ b/packages/core/src/ast/__tests__/serialize-projection-ratchet.test.ts
@@ -65,7 +65,9 @@ describe('V19 one-evaluator projection ratchet', () => {
     // frame-owned Map, not a WeakMap, by design.
     // +1 function (`reachedViaMixinSplice`): a chain walk keeping a ruleset's static
     // extend plan off its mixin-call splice placement (extend/splice fix).
-    expect(occurrences(/^function |^async function /gmu)).toBe(432);
+    // +1 function (`srcFile`): the active source file at a position-push site,
+    // read only when `trackPositions` is on (source-map generation).
+    expect(occurrences(/^function |^async function /gmu)).toBe(433);
     expect(occurrences(/new Map/gu)).toBe(59);
     expect(occurrences(/new Set/gu)).toBe(39);
     expect(occurrences(/new WeakMap/gu)).toBe(4);

--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -144,7 +144,7 @@ import { documentHasExtend, recordAstExtendProfile } from './extend/plan.js'; //
 import type { PlanInstruction, PlanOverlay, PlanReferenceAtRule, PlanSubject } from './extend/plan.js';
 import type { Level } from './extend/ir.js';
 import { branchFromSelector, descendantBranch, levelFromSelectorList } from './extend/ir.js';
-import { DocumentContext, documentTriviaOf, type Context } from '../context.js';
+import { DocumentContext, documentTriviaOf, type Context, type SourceContext } from '../context.js';
 import { Deprecation } from '../deprecation.js';
 import { ERR, WARN, toDiagnostic } from '../error/diagnostics.js';
 import { JessError } from '../error/jess-error.js';
@@ -194,6 +194,16 @@ export interface Position {
   type: NodeType;
   start: number;
   end: number;
+
+  /**
+   * The source file active when this chunk was emitted. Populated only when
+   * `trackPositions` is on, from `context.sourceContext.file` — which
+   * `withSourceOwner`/`withDocument` re-scope while emitting imported documents,
+   * so a position from an imported file carries THAT file's identity (its
+   * `_s`/`_e` offsets index into `source`), not the entry file's. This is what
+   * lets a multi-file source map attribute each mapping to the right file.
+   */
+  source?: SourceContext['file'];
 }
 
 export interface SerializeOptions {
@@ -7570,7 +7580,7 @@ function putValue(e: Emit, node: ValueSlot, frame: Frame | null, positionNode?: 
   const valStart = e.off;
   put(e, bytes);
   if (e.positions && positionNode) {
-    e.positions.push({ node: positionNode, type: positionNode.type, start: valStart, end: e.off });
+    e.positions.push({ node: positionNode, type: positionNode.type, start: valStart, end: e.off, source: srcFile(e) });
   }
   return bytes;
 }
@@ -7582,6 +7592,16 @@ function put(e: Emit, s: string): void {
   if (e.positions) {
     e.off += s.length;
   }
+}
+
+/**
+ * The source file active at this emit point. `context.sourceContext` follows the
+ * `withSourceOwner`/`withDocument` scope stack, so during an imported document's
+ * emission this returns the IMPORT's file (with its own `source` text and path).
+ * Read only from position-push sites, i.e. only when `trackPositions` is on.
+ */
+function srcFile(e: Emit): SourceContext['file'] {
+  return e.context?.sourceContext?.file;
 }
 
 /**
@@ -9878,7 +9898,7 @@ export function serialize(root: Stylesheet, options?: SerializeOptions): Seriali
     };
     const finish = (): SerializeReturn => {
       if (e.positions) {
-        e.positions.push({ node: root, type: root.type, start, end: e.off });
+        e.positions.push({ node: root, type: root.type, start, end: e.off, source: srcFile(e) });
       }
 
       // lift to async ONLY if a genuinely-async built-in reserved a placeholder.
@@ -14502,7 +14522,7 @@ function flushBlock(
       }
       put(e, header);
       if (e.positions && selNode) {
-        e.positions.push({ node: selNode, type: selNode.type, start: selStart, end: e.off });
+        e.positions.push({ node: selNode, type: selNode.type, start: selStart, end: e.off, source: srcFile(e) });
       }
       put(e, ' {\n');
     }
@@ -15150,7 +15170,7 @@ function emitMergedLine(e: Emit, name: string, combined: string, important: bool
   }
   put(e, ';\n');
   if (e.positions) {
-    e.positions.push({ node: any(combined), type: 'Any', start, end: e.off });
+    e.positions.push({ node: any(combined), type: 'Any', start, end: e.off, source: srcFile(e) });
   }
 }
 
@@ -15261,11 +15281,11 @@ function emitLeafOwned(leaf: Leaf, e: Emit, atRoot = false): void {
       const valStart = e.off;
       put(e, important ? normalizeImportant(customValue) : customValue);
       if (e.positions && !isValueSlotArray(node.value)) {
-        e.positions.push({ node: node.value, type: node.value.type, start: valStart, end: e.off });
+        e.positions.push({ node: node.value, type: node.value.type, start: valStart, end: e.off, source: srcFile(e) });
       }
     }
     if (e.positions) {
-      e.positions.push({ node, type: node.type, start, end: e.off });
+      e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
     }
     emitInlineBlockCommentTriviaAfter(node, e);
     put(e, ';\n');
@@ -15275,7 +15295,7 @@ function emitLeafOwned(leaf: Leaf, e: Emit, atRoot = false): void {
     put(e, node.text);
     put(e, '\n');
     if (e.positions) {
-      e.positions.push({ node, type: node.type, start, end: e.off });
+      e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
     }
   } else if (node.type === 'FunctionCall') {
     const bytes = evalBytesSync(node, frame, e);
@@ -15286,7 +15306,7 @@ function emitLeafOwned(leaf: Leaf, e: Emit, atRoot = false): void {
     put(e, bytes);
     put(e, '\n');
     if (e.positions) {
-      e.positions.push({ node, type: node.type, start, end: e.off });
+      e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
     }
   } else if (node.type === 'AtRuleBlock') {
     /*
@@ -15322,7 +15342,7 @@ function emitLeafOwned(leaf: Leaf, e: Emit, atRoot = false): void {
         put(e, asBytes(loaded));
       }
       if (e.positions) {
-        e.positions.push({ node, type: node.type, start, end: e.off });
+        e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
       }
     } else {
       e.depth++;
@@ -15693,7 +15713,7 @@ function emitAtRuleStatementRaw(
     putValueBoundaryTrivia(e, importBoundary.after, '');
     put(e, ';\n');
     if (e.positions) {
-      e.positions.push({ node, type: node.type, start, end: e.off });
+      e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
     }
     return;
   }
@@ -15704,7 +15724,7 @@ function emitAtRuleStatementRaw(
     put(e, authored);
     put(e, '\n');
     if (e.positions) {
-      e.positions.push({ node, type: node.type, start, end: e.off });
+      e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
     }
     return;
   }
@@ -15732,7 +15752,7 @@ function emitAtRuleStatementRaw(
   }
   put(e, ';\n');
   if (e.positions) {
-    e.positions.push({ node, type: node.type, start, end: e.off });
+    e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
   }
 }
 
@@ -15960,7 +15980,7 @@ function emitCssImportAtRule(node: StyleImport, frame: Frame, e: Emit): void {
   }
   put(e, ';\n');
   if (e.positions) {
-    e.positions.push({ node, type: node.type, start, end: e.off });
+    e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
   }
 }
 
@@ -16022,7 +16042,7 @@ function emitModuleImport(node: ModuleImport, frame: Frame, e: Emit): void {
     put(e, ';\n');
   }
   if (e.positions) {
-    e.positions.push({ node, type: node.type, start, end: e.off });
+    e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
   }
 }
 
@@ -16041,7 +16061,7 @@ function emitUnknownAtRuleBlock(node: UnknownAtRuleBlock, e: Emit): void {
   put(e, node.rawBody);
   put(e, '}\n');
   if (e.positions) {
-    e.positions.push({ node, type: node.type, start, end: e.off });
+    e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
   }
 }
 
@@ -16106,7 +16126,7 @@ function emitCallStatement(node: FunctionCall, frame: Frame, e: Emit, precompute
     put(e, bytes);
     put(e, '\n');
     if (e.positions) {
-      e.positions.push({ node, type: node.type, start, end: e.off });
+      e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
     }
   };
   const emitValueResult = (value: EvalValue): void => {
@@ -16695,7 +16715,7 @@ function writeCollapsedAtRuleBlock(
     }
     put(e, '}\n');
     if (e.positions) {
-      e.positions.push({ node, type: node.type, start, end: e.off });
+      e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
     }
   };
   return mapMaybe(emitted, () => {
@@ -17500,9 +17520,9 @@ function emitNestedLeafOwned(leaf: Leaf, e: Emit): void {
     markSilentStatementBlockCommentTrivia(node, e);
     if (e.positions) {
       if (!isValueSlotArray(node.value)) {
-        e.positions.push({ node: node.value, type: node.value.type, start: valStart, end: e.off });
+        e.positions.push({ node: node.value, type: node.value.type, start: valStart, end: e.off, source: srcFile(e) });
       }
-      e.positions.push({ node, type: node.type, start, end: e.off });
+      e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
     }
     emitInlineBlockCommentTriviaAfter(node, e);
     put(e, ';\n');
@@ -17514,7 +17534,7 @@ function emitNestedLeafOwned(leaf: Leaf, e: Emit): void {
     put(e, node.text);
     put(e, '\n');
     if (e.positions) {
-      e.positions.push({ node, type: node.type, start, end: e.off });
+      e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
     }
   }
 }
@@ -17813,7 +17833,7 @@ function writeNestedRule(
       headerChunkIndex = e.chunks.length;
       put(e, header);
       if (e.positions) {
-        e.positions.push({ node: rule.selector, type: rule.selector.type, start: selStart, end: e.off });
+        e.positions.push({ node: rule.selector, type: rule.selector.type, start: selStart, end: e.off, source: srcFile(e) });
       }
       put(e, ' {\n');
     }
@@ -17847,7 +17867,7 @@ function writeNestedRule(
         }
         put(e, '}\n');
         if (e.positions) {
-          e.positions.push({ node: rule, type: rule.type, start, end: e.off });
+          e.positions.push({ node: rule, type: rule.type, start, end: e.off, source: srcFile(e) });
         }
         if (rootSibling) {
           lb.parentKey = frame;
@@ -17987,7 +18007,7 @@ function writeNestedAtRuleBlock(
     }
     put(e, '}\n');
     if (e.positions) {
-      e.positions.push({ node, type: node.type, start, end: e.off });
+      e.positions.push({ node, type: node.type, start, end: e.off, source: srcFile(e) });
     }
   };
   return mapMaybe(

--- a/packages/core/src/ast/sourcemap.ts
+++ b/packages/core/src/ast/sourcemap.ts
@@ -1,0 +1,126 @@
+import {
+  GenMapping,
+  maybeAddMapping,
+  setSourceContent,
+  toEncodedMap,
+  type EncodedSourceMap
+} from '@jridgewell/gen-mapping';
+import { lineColAt } from '../error/code-frame.js';
+import { sourceStartOf, NO_SPAN } from './provenance.js';
+import type { Position } from './serialize.js';
+
+/**
+ * Source-map generation for the LIVE AST-v2 render path.
+ *
+ * The one existing emit walk records a dense {@link Position} stream: each entry
+ * is a chunk's OUTPUT character range plus the node it came from (whose source
+ * offset is `sourceStartOf(node)`) and the source FILE active at emit time. This
+ * turns that stream into a v3 source map, closing the three gaps the serializer
+ * left open:
+ *   1. output offset -> {line,col}: one line-start index over the final CSS, then
+ *      a binary search per position (never a per-position rescan);
+ *   2. source offset -> {line,col}: the shared `lineColAt`, whose line-start
+ *      index is cached per source file (keyed by the file object);
+ *   3. per-position source-file identity: `Position.source`, stamped at each push
+ *      from the active source owner, so imported files map to themselves.
+ *
+ * Mirrors Less 4.x `SourceMapOutput`/`SourceMapBuilder` shape: one mapping per
+ * emitted chunk, `normalizeFilename` (basepath strip + rootpath prefix), and
+ * `sourcesContent` under `outputSourceFiles`.
+ */
+export interface AstSourceMapOptions {
+  /** Recorded as the map's `file` (the generated output filename). */
+  outputFilename?: string;
+
+  /** Prepended to every `source` after basepath removal (Less `sourceMapRootpath`). */
+  sourceMapRootpath?: string;
+
+  /** Stripped from the front of every source path (Less `sourceMapBasepath`). */
+  sourceMapBasepath?: string;
+
+  /** Embed each source file's content in `sourcesContent` (Less `outputSourceFiles`). */
+  outputSourceFiles?: boolean;
+}
+
+/** One-pass line-start index over the generated CSS. */
+function buildLineStarts(source: string): number[] {
+  const lineStarts = [0];
+  for (let offset = 0; offset < source.length; offset++) {
+    if (source.charCodeAt(offset) === 10 /* \n */) {
+      lineStarts.push(offset + 1);
+    }
+  }
+  return lineStarts;
+}
+
+/** 1-based line, 0-based column at an output offset via binary search. */
+function lineColFromIndex(lineStarts: number[], offset: number): { line: number; column: number } {
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low < high) {
+    const middle = (low + high + 1) >>> 1;
+    if (lineStarts[middle]! <= offset) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return { line: low + 1, column: offset - lineStarts[low]! };
+}
+
+/** Less `normalizeFilename`: basepath removal, then rootpath prefix. */
+function normalizeFilename(filename: string, rootpath: string, basepath: string | undefined): string {
+  let path = filename.replace(/\\/g, '/');
+  if (basepath !== undefined && basepath !== '' && path.indexOf(basepath) === 0) {
+    path = path.substring(basepath.length);
+    if (path.charAt(0) === '/' || path.charAt(0) === '\\') {
+      path = path.substring(1);
+    }
+  }
+  return rootpath + path;
+}
+
+/**
+ * Build a v3 source map from the render's position stream and its generated CSS.
+ * Positions with no resolvable source (no active file, no captured source text,
+ * or an unspanned node) contribute no mapping — the map is still valid, just
+ * sparser at those points.
+ */
+export function buildAstSourceMap(
+  css: string,
+  positions: Position[],
+  options: AstSourceMapOptions = {}
+): EncodedSourceMap {
+  const genLineStarts = buildLineStarts(css);
+  const rootpath = options.sourceMapRootpath ?? '';
+  const basepath = options.sourceMapBasepath?.replace(/\\/g, '/');
+  const map = new GenMapping({ file: options.outputFilename });
+  const contentAdded = new Set<string>();
+
+  for (const position of positions) {
+    const file = position.source;
+    const filename = file?.fullPath;
+    const sourceText = file?.source;
+    if (filename === undefined || sourceText === undefined) {
+      continue;
+    }
+    const sourceOffset = sourceStartOf(position.node);
+    if (sourceOffset === NO_SPAN) {
+      continue;
+    }
+    const generated = lineColFromIndex(genLineStarts, position.start);
+    const original = lineColAt(sourceText, sourceOffset, file);
+    const source = normalizeFilename(filename, rootpath, basepath);
+    maybeAddMapping(map, {
+      generated: { line: generated.line, column: generated.column },
+      original: { line: original.line, column: original.column - 1 },
+      source
+    });
+    if (options.outputSourceFiles === true && !contentAdded.has(source)) {
+      contentAdded.add(source);
+      setSourceContent(map, source, sourceText);
+    }
+  }
+
+  return toEncodedMap(map);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,7 +34,11 @@ export type { ApplySelectorKind, ExtendSelectorKind, SelectorPolicyKind } from '
 
 /** Canonical AST-v2 stylesheet execution. Parser construction stays under `./ast`. */
 export { prepareStaticImports, serialize } from './ast/serialize.js';
-export type { PreparedImports, PrepareStaticImportsOptions, SerializeOptions } from './ast/serialize.js';
+export type { PreparedImports, PrepareStaticImportsOptions, SerializeOptions, Position } from './ast/serialize.js';
+
+/** Build a v3 source map from the render's position stream (see `trackPositions`). */
+export { buildAstSourceMap } from './ast/sourcemap.js';
+export type { AstSourceMapOptions } from './ast/sourcemap.js';
 
 /** Construct the typed value evaluator used by the canonical AST-v2 execution path. */
 export { buildEvaluator } from './ast/evaluator.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,22 @@ export interface StylesConfig {
   output?: {
     collapseNesting?: boolean;
     compress?: boolean;
-    sourceMap?: boolean;
+
+    /**
+     * Source-map generation. `true` turns it on with defaults; the object form
+     * carries the Less-compatible sub-options (basepath/rootpath/inline/…). The
+     * full option list is documented on `ConfigOptions` in `./types/config.ts`.
+     */
+    sourceMap?: boolean | {
+      sourceMapFullFilename?: string;
+      sourceMapRootpath?: string;
+      sourceMapBasepath?: string;
+      sourceMapURL?: string;
+      sourceMapFileInline?: boolean;
+      outputSourceFiles?: boolean;
+      disableSourcemapAnnotation?: boolean;
+      sourceMapOutputFilename?: string;
+      sourceMapFilename?: string;
+    };
   };
 }

--- a/packages/jess/test/sourcemap.test.ts
+++ b/packages/jess/test/sourcemap.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Compiler } from '../src/index.js';
+
+/**
+ * Minimal base64-VLQ source-map decoder. Returns every mapping as absolute
+ * values so a test can assert that a generated position resolves to the right
+ * source FILE + line + column — the multi-file (`@import`) correctness crux.
+ */
+const B64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+interface DecodedMapping {
+  genLine: number; // 0-based
+  genColumn: number; // 0-based
+  sourceIndex: number;
+  sourceLine: number; // 0-based
+  sourceColumn: number; // 0-based
+}
+
+function decodeMappings(mappings: string): DecodedMapping[] {
+  const out: DecodedMapping[] = [];
+  let sourceIndex = 0;
+  let sourceLine = 0;
+  let sourceColumn = 0;
+  const lines = mappings.split(';');
+  for (let genLine = 0; genLine < lines.length; genLine++) {
+    let genColumn = 0;
+    const segments = lines[genLine]!.length === 0 ? [] : lines[genLine]!.split(',');
+    for (const segment of segments) {
+      const fields = decodeVlqSegment(segment);
+      genColumn += fields[0]!;
+      if (fields.length >= 4) {
+        sourceIndex += fields[1]!;
+        sourceLine += fields[2]!;
+        sourceColumn += fields[3]!;
+        out.push({ genLine, genColumn, sourceIndex, sourceLine, sourceColumn });
+      }
+    }
+  }
+  return out;
+}
+
+function decodeVlqSegment(segment: string): number[] {
+  const values: number[] = [];
+  let shift = 0;
+  let value = 0;
+  for (const char of segment) {
+    const digit = B64.indexOf(char);
+    const continuation = digit & 32;
+    value += (digit & 31) << shift;
+    if (continuation) {
+      shift += 5;
+    } else {
+      const negate = value & 1;
+      value >>= 1;
+      values.push(negate ? -value : value);
+      value = 0;
+      shift = 0;
+    }
+  }
+  return values;
+}
+
+interface V3Map {
+  version: number;
+  sources: string[];
+  names: string[];
+  mappings: string;
+  file?: string;
+  sourcesContent?: string[];
+}
+
+describe('source map generation (live AST-v2 render path)', () => {
+  let dir: string;
+  let entry: string;
+  let importedPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jess-sourcemap-'));
+    importedPath = path.join(dir, 'imported.less');
+    entry = path.join(dir, 'entry.less');
+    fs.writeFileSync(importedPath, '.imported {\n  color: green;\n}\n');
+    fs.writeFileSync(entry, '@import "imported";\n.entry {\n  color: red;\n}\n');
+  });
+
+  afterEach(() => {
+    if (dir && fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('emits the annotation and maps a generated position back to the IMPORTED file', async () => {
+    const result = await new Compiler().renderToResult(entry, {
+      output: { sourceMap: { outputSourceFiles: true, sourceMapFilename: 'entry.css.map' } }
+    });
+
+    // (a) annotation present
+    expect(result.css).toContain('/*# sourceMappingURL=entry.css.map */');
+    expect(result.sourceMapURL).toBe('entry.css.map');
+    expect(result.map).toBeTypeOf('string');
+
+    const map = JSON.parse(result.map!) as V3Map;
+    expect(map.version).toBe(3);
+    expect(map.names).toEqual([]);
+
+    /* both files present; outputSourceFiles embeds their content */
+    expect(map.sources).toContain(importedPath);
+    expect(map.sources).toContain(entry);
+    expect(map.sourcesContent).toBeDefined();
+    const importedSourceIndex = map.sources.indexOf(importedPath);
+    expect(map.sourcesContent![importedSourceIndex]).toContain('.imported');
+
+    /*
+     * (b) THE CRUX: a generated position resolves to the imported file.
+     * `.imported` is emitted verbatim at the top of the output.
+     */
+    const cssLines = result.css.split('\n');
+    const genLine = cssLines.findIndex(line => line.startsWith('.imported'));
+    expect(genLine).toBeGreaterThanOrEqual(0);
+
+    const decoded = decodeMappings(map.mappings);
+    const importedMappings = decoded.filter(m => m.sourceIndex === importedSourceIndex);
+    expect(importedMappings.length).toBeGreaterThan(0);
+
+    // The `.imported` selector: generated line start -> imported.less line 1, col 0.
+    const selectorMapping = importedMappings.find(m => m.genLine === genLine && m.genColumn === 0);
+    expect(selectorMapping).toBeDefined();
+    expect(selectorMapping!.sourceLine).toBe(0); // 0-based line 1
+    expect(selectorMapping!.sourceColumn).toBe(0);
+
+    // A declaration inside the imported file (`color: green;` is indented 2 cols).
+    const declGenLine = cssLines.findIndex(line => line.includes('color: green'));
+    const declMapping = importedMappings.find(m => m.genLine === declGenLine);
+    expect(declMapping).toBeDefined();
+    expect(declMapping!.sourceLine).toBe(1); // 0-based line 2
+    expect(declMapping!.sourceColumn).toBe(2); // after two spaces of indent
+  });
+
+  it('honors sourceMapFileInline / disableSourcemapAnnotation / sourceMapRootpath', async () => {
+    const inline = await new Compiler().renderToResult(entry, {
+      output: { sourceMap: { sourceMapFileInline: true } }
+    });
+    expect(inline.css).toMatch(/sourceMappingURL=data:application\/json;base64,[A-Za-z0-9+/=]+/);
+
+    const disabled = await new Compiler().renderToResult(entry, {
+      output: { sourceMap: { sourceMapFilename: 'x.map', disableSourcemapAnnotation: true } }
+    });
+    expect(disabled.css).not.toContain('sourceMappingURL');
+    expect(disabled.map).toBeTypeOf('string'); // map still produced for external write
+
+    const rooted = await new Compiler().renderToResult(entry, {
+      output: { sourceMap: { sourceMapRootpath: 'assets/', sourceMapBasepath: dir } }
+    });
+    const rootedMap = JSON.parse(rooted.map!) as V3Map;
+    expect(rootedMap.sources).toContain('assets/imported.less');
+    expect(rootedMap.sources).toContain('assets/entry.less');
+  });
+
+  it('is zero-cost when off: no annotation and byte-identical to a bare render', async () => {
+    const off = await new Compiler().renderToResult(entry, {});
+    expect(off.css).not.toContain('sourceMappingURL');
+    expect(off.map).toBeUndefined();
+    expect(off.sourceMapURL).toBeUndefined();
+
+    const bare = await new Compiler().render(entry, {});
+    expect(bare).toBe(off.css);
+  });
+});


### PR DESCRIPTION
## What

Implements Less-compatible **source-map generation** in the live AST-v2 renderer. `renderToResult` now returns a v3 source map alongside the CSS.

## How

The serializer already recorded a dense node→output-offset `Position` stream under `trackPositions`; this turns it into a v3 map, closing three gaps:
1. **output offset → line/col** — one-pass line index over the final CSS + binary search (no per-position rescan).
2. **source offset → line/col** — the shared `lineColAt` (cached per source file).
3. **per-position source-file identity** (the real gap) — new `Position.source`, stamped at each push from `context.sourceContext.file` (which `withSourceOwner`/`withDocument` re-scope per imported document), so a position emitted from an imported file maps to **that** file.

New `packages/core/src/ast/sourcemap.ts` builds the map via `@jridgewell/gen-mapping` (already a core dep), mirroring Less 4.x `SourceMapOutput`/`SourceMapBuilder`: `normalizeFilename` (basepath strip + rootpath prefix), `sourcesContent` under `outputSourceFiles`, and the `getCSSAppendage` annotation policy (explicit `sourceMapURL` > `sourceMapFilename`; `sourceMapFileInline` → base64 `data:` URI; `disableSourcemapAnnotation` → none).

**Also fixes a bug:** the compiler coerced the `sourceMap` option to a bool, silently dropping the object sub-options (`sourceMapBasepath`/`sourceMapRootpath`/…). Now preserved.

## Scope / notes

- `renderToResult` → `{ css, errors, warnings, loadedUrls, map?, sourceMapURL? }`; `render`/`renderString` stay bare strings. External `.map`-to-disk is a caller concern (no file-writing CLI added).
- Zero cost when off: `trackPositions` is only enabled when `sourceMap` is truthy; `put()` bumps offsets only when tracking — a bare render is byte-identical (verified).
- Map is generated pre-post-processor, same limitation as Less 4.x.
- **compress/minify is the deferred follow-up** and builds on this position-aware emit (sourcemap-first was chosen so compressed mappings stay valid for free).

## Tests

- New `packages/jess/test/sourcemap.test.ts`: decodes the v3 map and proves a generated position maps back to the **imported** file (line/col); the option matrix (inline / disable / rootpath / `sourcesContent`); and zero-cost byte-identity when off.
- Full core (3304), jess Less (677), projection ratchet (bumped 432→433 for the new helper) all green; no `as any`/`@ts-ignore`.