### PR TITLE
fix(compiler): honor language.less.compress config + keyword-color non-goal doc

### DIFF
--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1003,7 +1003,14 @@ export class Compiler {
       ? resolved.effectiveConfig.output
       : null;
     contextOptions.output = {
-      compress: cfgOutput?.compress,
+      /*
+       * `output.compress` wins, but the Less config shape carries it as
+       * `language.less.compress` — surfaced on `activeOptions` by `getOptions`.
+       * Fall back to it so a less.js-style config (and the corpus fixtures)
+       * honor `compress` without nesting it under `output`.
+       */
+      compress: cfgOutput?.compress
+        ?? (typeof resolved.activeOptions?.compress === 'boolean' ? resolved.activeOptions.compress : undefined),
 
       /*
        * Preserve the object form (sourceMapBasepath/rootpath/inline/…); coercing

--- a/packages/docs/docs-content/docs/less/advanced/compressed-output.md
+++ b/packages/docs/docs-content/docs/less/advanced/compressed-output.md
@@ -132,9 +132,14 @@ These change structure or risk the cascade and are **not** part of `compress`
 - Merging or deduplicating rules, selectors, or declarations.
 - Reordering declarations or rules.
 - Longhand ↔ shorthand rewriting (`margin: 0 0 0 0` → `margin: 0`).
-- Color-representation conversion (`rgb()`/`hsl()` → hex, or hex → named) —
-  a future finer-grained option; `compress` only shortens a color *within* its
-  representation (hex fold, named ↔ hex).
+- Color-representation conversion (`rgb()`/`hsl()` → hex) — a future
+  finer-grained option; `compress` only shortens a value already classified as a
+  color (hex fold; shortest of hex/name).
+- Folding a color **keyword** (`color: white` → `#fff`) — a firm non-goal, not a
+  deferral. A bare keyword can only be recognized as a color from its property's
+  value grammar (`color` vs `animation-name`/`font-family`), and jess does not
+  consult a per-property table; folding it without one would corrupt non-color
+  uses of the same word. `white` stays `white`.
 - Dropping the unit on a zero value (`0px` → `0`) — not context-free.
 - `calc()` simplification / constant folding of authored expressions.
 - `@media` query merging — Jess never merges media queries regardless of

--- a/packages/jess/test/less/compress-config-mapping.test.ts
+++ b/packages/jess/test/less/compress-config-mapping.test.ts
@@ -1,0 +1,26 @@
+/**
+ * The Less config shape carries `compress` as `language.less.compress` (not
+ * `output.compress`). jess must honor it so a less.js-style config — and the
+ * corpus's `tests-config/*compress*` fixtures — minify. `output.compress` still
+ * wins when both are present.
+ */
+import { describe, it, expect } from 'vitest';
+import { Compiler } from '../../src/index.js';
+import lessPlugin from '@jesscss/plugin-less';
+
+const render = async (opts: Record<string, unknown>): Promise<string> => {
+  const c = new Compiler({ ...opts, compile: { plugins: [lessPlugin()] } } as never);
+  return (await c.renderToResult({ source: '.a { color: red; margin: 0px; }', language: 'less', extension: '.less' }, {})).css.trim();
+};
+
+describe('language.less.compress maps to the compress option', () => {
+  it('language.less.compress: true minifies', async () => {
+    expect(await render({ language: { less: { compress: true } } })).toBe('.a{color:red;margin:0px}');
+  });
+  it('no compress → pretty', async () => {
+    expect(await render({ output: { collapseNesting: true } })).toBe('.a {\n  color: red;\n  margin: 0px;\n}');
+  });
+  it('output.compress wins when both set', async () => {
+    expect(await render({ output: { compress: false }, language: { less: { compress: true } } })).toBe('.a {\n  color: red;\n  margin: 0px;\n}');
+  });
+});


### PR DESCRIPTION
Prerequisite for graduating the corpus `*compress*` fixtures.

## Config mapping
The Less config shape carries `compress` as `language.less.compress` (which `getOptions` surfaces on `activeOptions`), but the compiler only read `config.output.compress` — so a less.js-style config, and the corpus `tests-config/compression`/`at-rules-compressed` fixtures, rendered **uncompressed**. Fall back to `activeOptions.compress` (with `output.compress` still winning). Verified by `compress-config-mapping.test.ts` (maps; precedence; off→pretty).

## Doc
Records that folding a color **keyword** (`color: white`→`#fff`) is a **firm non-goal**, not a deferral — a bare keyword's color-ness is only knowable from its property's value grammar, which jess deliberately doesn't consult, so folding it would corrupt non-color uses (`animation-name: white`, etc.).

Follow-up (separate PR): regenerate the `at-rules-compressed*` goldens to jess's v5 compressed output and graduate them; `compression.less` needs its dead shadow-piercing (`^`/`^^`) selectors removed first (dropped from CSS).