### PR TITLE
test(less): graduate at-rules-compressed + at-rules-compressed-evaluation

### DIFF
--- a/packages/jess/test/less/all-less.test.ts
+++ b/packages/jess/test/less/all-less.test.ts
@@ -185,9 +185,7 @@ const skippedFixtures: SkippedFixture[] = (
      * Config fixtures that need a dedicated compatibility decision or feature
      * work before they can be release gates.
      */
-    'tests-config/at-rules-compressed/at-rules-compressed.less', // compression output parity not yet alpha-gated
-    'tests-config/at-rules-compressed-evaluation/at-rules-compressed-evaluation.less', // compression output parity not yet alpha-gated
-    'tests-config/compression/compression.less', // compression output parity not yet alpha-gated
+    'tests-config/compression/compression.less', // parses only after its dead shadow-piercing (^/^^) selectors are removed, and needs function-arg comma tightening (rgba(…) args) to match the v5 superset golden — separate follow-up
     'tests-config/debug/linenumbers.less', // debug output fixture; no expected CSS in upstream fixture
     'tests-config/filemanagerPlugin/filemanager.less', // custom Less file manager plugin API needs scope decision
     'tests-config/include-path/import-test-e.less', // helper imported by include-path fixture; no expected CSS


### PR DESCRIPTION
Graduates the two `at-rules-compressed*` fixtures now that #201 makes jess honor `language.less.compress`.

jess compresses them to a **v5 superset** of the Less 4.x golden:
- tightens `@supports (display: grid)` → `@supports(display:grid)`;
- **nests** conditional group rules (`@media screen{@media print{…}}`) instead of 4.x's merged `@media screen and print` (v5 doesn't merge media — O2).

Everything else is byte-identical. The reconciled goldens are pushed to `matthew-dean/less.js@alpha` (this suite's corpus).

`compression.less` stays on the list with an accurate reason — it parses only after its dead shadow-piercing (`^`/`^^`) selectors are removed (dropped from CSS), and needs function-arg comma tightening (`rgba(…)` args) to be a full superset; tracked as a follow-up.