### PR TITLE
feat(compress): tighten comma list-dividers in function args

### DIFF
--- a/packages/core/src/ast/evaluator.ts
+++ b/packages/core/src/ast/evaluator.ts
@@ -22,15 +22,20 @@ import type { FnRegistry } from './value-dispatch.js';
 import { dispatchFn } from './value-dispatch.js';
 import { makeKeyword } from './value-factory.js';
 
-/** Join an unknown-fn's arg bytes verbatim (per separator). */
-function verbatimArgs(args: ValueGroup): string {
+/** Join an unknown-fn's arg bytes verbatim (per separator). Under compress the
+ *  comma list-divider tightens (`,`); space and `/` separators are significant
+ *  and kept (v5 keeps `/` spaced). Arg SPELLINGS stay verbatim either way. */
+function verbatimArgs(args: ValueGroup, modes?: EvalModes): string {
   const separator = groupSeparator(args);
-  return groupItems(args).map(emitValue).join(separator === ' ' ? ' ' : sepGlue(separator));
+  const glue = separator === ' '
+    ? ' '
+    : (separator === ',' && modes?.compress === true ? ',' : sepGlue(separator));
+  return groupItems(args).map(emitValue).join(glue);
 }
 
 /** Preserve an optional CSS call after name resolution or invocation failed. */
-function fallbackCall(name: string, args: ValueGroup): Value {
-  return makeKeyword(`${name}(${verbatimArgs(args)})`);
+function fallbackCall(name: string, args: ValueGroup, modes?: EvalModes): Value {
+  return makeKeyword(`${name}(${verbatimArgs(args, modes)})`);
 }
 
 /**
@@ -47,7 +52,7 @@ function recoverCallFailure(
   if (modes.functionMode === 'error') {
     throw error;
   }
-  return fallbackCall(name, args);
+  return fallbackCall(name, args, modes);
 }
 
 /** Keep the ordinary synchronous path allocation-free; attach recovery only to an async result. */
@@ -123,7 +128,7 @@ export function buildEvaluator(registry: FnRegistry): ValueEvaluator {
     }
 
     // Unknown function: emit verbatim.
-    return fallbackCall(name, args);
+    return fallbackCall(name, args, modes);
   };
 
   /* The callee's declared parameter names — the binding surface a keyword

--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -5436,8 +5436,8 @@ function preserveCall(node: FunctionCall, frame: Frame | null, e: EvalCtx): Mayb
   const items = node.args.map(a => evalValueSlot(a.value, frame, preserve));
   return combineAll(items, (vals) => {
     const authored = valueLayoutOf(node.args);
-    const glue = node.modern ? ' ' : ', ';
-    let inner = emitValue(vals[0]!);
+    const glue = node.modern ? ' ' : (e.compress === true ? ',' : ', ');
+    let inner = emitValueC(vals[0]!, e);
     for (let index = 1; index < vals.length; index += 1) {
       const separator = authored?.[index - 1];
 
@@ -5448,7 +5448,7 @@ function preserveCall(node: FunctionCall, frame: Frame | null, e: EvalCtx): Mayb
        * verbatim are a newline + its indentation offset and a block comment.
        */
       inner += separator !== undefined && /[\r\n]|\/\*/u.test(separator) ? separator : glue;
-      inner += emitValue(vals[index]!);
+      inner += emitValueC(vals[index]!, e);
     }
     return literal(`${node.name}(${inner})`);
   });
@@ -6348,12 +6348,12 @@ function evalCall(
     const items = node.args.map(a => evalValueSlot(a.value, frame, e));
     return combineAll(items, (vals) => {
       const authored = valueLayoutOf(node.args);
-      const glue = sep === ' ' ? ' ' : ', ';
-      let inner = emitValue(vals[0]!);
+      const glue = sep === ' ' ? ' ' : (e.compress === true ? ',' : ', ');
+      let inner = emitValueC(vals[0]!, e);
       for (let index = 1; index < vals.length; index += 1) {
         const separator = authored?.[index - 1];
         inner += separator !== undefined && /[\r\n]|\/\*/u.test(separator) ? separator : glue;
-        inner += emitValue(vals[index]!);
+        inner += emitValueC(vals[index]!, e);
       }
       return literal(`${node.name}(${inner})`);
     });
@@ -9847,7 +9847,7 @@ export function prepareStaticImports(root: Stylesheet, options?: PrepareStaticIm
     off: 0,
     positions: null,
     ev: options?.evaluator ?? options?.context?.evaluator ?? null,
-    modes: options?.modes ?? options?.context?.options ?? DEFAULT_MODES,
+    modes: { ...(options?.modes ?? options?.context?.options ?? DEFAULT_MODES), compress: options?.compress ?? false },
     allowCallerScope: options?.context?.options.allowCallerScope ?? options?.modes?.allowCallerScope ?? false,
     trivia: options?.trivia ?? triviaMapOf(root) ?? options?.context?.opts.trivia,
     context: options?.context,
@@ -9934,7 +9934,7 @@ export function serialize(root: Stylesheet, options?: SerializeOptions): Seriali
     off: 0,
     positions: options?.trackPositions ? [] : null,
     ev: options?.evaluator ?? options?.context?.evaluator ?? null, // typed value evaluator
-    modes: options?.modes ?? options?.context?.options ?? DEFAULT_MODES,
+    modes: { ...(options?.modes ?? options?.context?.options ?? DEFAULT_MODES), compress: options?.compress ?? false },
     allowCallerScope: options?.context?.options.allowCallerScope ?? options?.modes?.allowCallerScope ?? false, // [R16] legacy caller-read, default hermetic
     trivia: options?.trivia ?? triviaMapOf(root) ?? options?.context?.opts.trivia,
     context: options?.context,

--- a/packages/core/src/ast/value-eval.ts
+++ b/packages/core/src/ast/value-eval.ts
@@ -378,6 +378,13 @@ export interface EvalModes {
    * supplies it (its resolved options already carry the field). Absent = hermetic.
    */
   readonly allowCallerScope?: boolean;
+
+  /**
+   * [compress] Minified output. Carried here so the evaluator's verbatim
+   * unknown-fn fallback can tighten the comma list-divider (`a(1, 2)`→`a(1,2)`)
+   * on the same `modes` path the Context supplies; absent = pretty.
+   */
+  readonly compress?: boolean;
 }
 
 export const DEFAULT_MODES: EvalModes = {

--- a/packages/jess/test/compress.test.ts
+++ b/packages/jess/test/compress.test.ts
@@ -96,6 +96,25 @@ describe('output.compress — value folds (must fold)', () => {
       .toBe('a{transition:color 1px,background 2px}');
   });
 
+  it('tightens function-arg commas (list dividers) but keeps significant spaces', async () => {
+    /*
+     * The list-divider (comma) space is minified. A CSS-shaped call whose bytes are
+     * PRESERVED (rgba/rgb/hsl/… in a .less doc) keeps its arg spellings verbatim —
+     * the commas tighten, but the `0.1` is NOT re-spelled to `.1`: a preserved arg
+     * is an opaque string, and re-tokenizing it to fold would defeat preservation.
+     */
+    expect(await min('a { color: rgba(255, 238, 170, 0.1) }'))
+      .toBe('a{color:rgba(255,238,170,0.1)}');
+
+    // a generic (evaluated) call folds via typed nodes AND tightens commas
+    expect(await min('a { transform: translate(1px, 2px) }'))
+      .toBe('a{transform:translate(1px,2px)}');
+
+    // modern space-separated color syntax: the spaces ARE the separators, kept
+    expect(await min('a { color: rgb(15 23 42 / 0.5) }'))
+      .toBe('a{color:rgb(15 23 42 / 0.5)}');
+  });
+
   it('emits `!important` with no leading space', async () => {
     expect(await min('a { color: red !important }')).toBe('a{color:red!important}');
   });


### PR DESCRIPTION
Under `output.compress`, the comma separating list items now tightens to a bare `,` inside function-argument lists, matching the whitespace already stripped from top-level value lists and selector lists.

```
rgba(255, 238, 170, 0.1)  ->  rgba(255,238,170,0.1)
translate(1px, 2px)       ->  translate(1px,2px)
min(1rem, 2rem)           ->  min(1rem,2rem)
```

### Why three edits

The comma glue was written in three emit paths and only the top-level value list consulted `compress`:

- **`preserveCall`** (CSS-shaped color constructors kept verbatim in a `.less` doc) and the **`!e.ev` generic loop** now derive the separator from `e.compress`.
- The **evaluator's unknown-function fallback** (`verbatimArgs`, e.g. `translate`, `clamp`, any unresolved CSS function) had no compress context. `compress` now rides `EvalModes` — the same per-render policy bag that already carries `unitMode`/`mathMode`/`functionMode` — so the fallback can tighten it.

### Scope

Only the **comma** divider tightens. Space separators are significant and kept (modern `rgb(15 23 42 / .5)`), and `/` stays spaced per the v5 spaced-separator rule. In the preserved path the argument **spellings** stay verbatim (a preserved argument is an opaque string; re-spelling it would mean re-tokenizing — out of scope for compress).

Classification-driven throughout: every join operates on already-parsed argument nodes, never on re-scanned serialized bytes.

### Tests

New cases in `packages/jess/test/compress.test.ts` cover the preserved color call, a generic function, and the modern space-separated form. Full `packages/core` ast suite (513) and the jess Less corpus (209) pass with no regressions.