### PR TITLE
fix(compress): fold dimension args in preserved color calls by classification

### DIFF
--- a/packages/_shared/index.ts
+++ b/packages/_shared/index.ts
@@ -97,9 +97,6 @@ export const invalidLess: string[] = [
   /** Comment-only deprecated-combinator fixture; empty render differs from its one-newline golden. */
   'tests-unit/parser-slashed-combinator/parser-slashed-combinator.less',
 
-  /** Obsolete Less parent selectors `^` / `^^` were removed in Less v5 */
-  'tests-config/compression/compression.less',
-
   /** Inline JavaScript using backticks is intentionally unsupported */
   'tests-unit/javascript/javascript.less',
   'tests-config/js-type-errors/js-type-error.less',

--- a/packages/core/src/ast/serialize.ts
+++ b/packages/core/src/ast/serialize.ts
@@ -3947,8 +3947,16 @@ function evalValue(node: ValueNode, frame: Frame | null, e: EvalCtx): MaybePromi
       /*
        * Typed materialization owns Less's numeric spelling canonicalization
        * (`.3s` → `0.3s`) without a post-render CSS rewrite.
+       *
+       * [compress] The byte lane (`ev === null`, the preserved-call arg path) keeps
+       * a dimension's authored spelling — EXCEPT that `output.compress` folds it by
+       * its CLASSIFICATION here, exactly as `emitValueC` does for the typed lane. A
+       * `Dimension` is a `Dimension` whatever position it lands in, so `rgba(…,0.1)`
+       * trims to `.1` off the node type, never by re-scanning the joined arg string.
        */
-      return e.ev ? dimensionFromFields(node.number, node.unit, node.src) : literal(node.src);
+      return e.ev
+        ? dimensionFromFields(node.number, node.unit, node.src)
+        : literal(e.compress === true ? compressDimensionBytes(node.src) : node.src);
     case 'Quoted':
       return literal(node.escaped ? node.value : node.src);
     case 'Url':

--- a/packages/jess/test/compress.test.ts
+++ b/packages/jess/test/compress.test.ts
@@ -96,23 +96,27 @@ describe('output.compress — value folds (must fold)', () => {
       .toBe('a{transition:color 1px,background 2px}');
   });
 
-  it('tightens function-arg commas (list dividers) but keeps significant spaces', async () => {
+  it('tightens function-arg commas (list dividers) and folds args by classification', async () => {
     /*
      * The list-divider (comma) space is minified. A CSS-shaped call whose bytes are
-     * PRESERVED (rgba/rgb/hsl/… in a .less doc) keeps its arg spellings verbatim —
-     * the commas tighten, but the `0.1` is NOT re-spelled to `.1`: a preserved arg
-     * is an opaque string, and re-tokenizing it to fold would defeat preservation.
+     * PRESERVED (rgba/rgb/hsl/… in a .less doc) keeps its arg SEPARATORS verbatim,
+     * but each arg is still folded by its NODE CLASSIFICATION — a `Dimension` arg
+     * trims its leading zero (`0.1`→`.1`) off the node type, never by re-scanning the
+     * joined string. Position does not change a token's shape.
      */
     expect(await min('a { color: rgba(255, 238, 170, 0.1) }'))
-      .toBe('a{color:rgba(255,238,170,0.1)}');
+      .toBe('a{color:rgba(255,238,170,.1)}');
 
     // a generic (evaluated) call folds via typed nodes AND tightens commas
     expect(await min('a { transform: translate(1px, 2px) }'))
       .toBe('a{transform:translate(1px,2px)}');
 
-    // modern space-separated color syntax: the spaces ARE the separators, kept
+    /*
+     * modern space-separated color syntax: the spaces/`/` ARE the separators (kept),
+     * but the alpha `Dimension` still folds its leading zero
+     */
     expect(await min('a { color: rgb(15 23 42 / 0.5) }'))
-      .toBe('a{color:rgb(15 23 42 / 0.5)}');
+      .toBe('a{color:rgb(15 23 42 / .5)}');
   });
 
   it('emits `!important` with no leading space', async () => {

--- a/packages/jess/test/less/all-less.test.ts
+++ b/packages/jess/test/less/all-less.test.ts
@@ -185,7 +185,6 @@ const skippedFixtures: SkippedFixture[] = (
      * Config fixtures that need a dedicated compatibility decision or feature
      * work before they can be release gates.
      */
-    'tests-config/compression/compression.less', // parses only after its dead shadow-piercing (^/^^) selectors are removed, and needs function-arg comma tightening (rgba(…) args) to match the v5 superset golden — separate follow-up
     'tests-config/debug/linenumbers.less', // debug output fixture; no expected CSS in upstream fixture
     'tests-config/filemanagerPlugin/filemanager.less', // custom Less file manager plugin API needs scope decision
     'tests-config/include-path/import-test-e.less', // helper imported by include-path fixture; no expected CSS


### PR DESCRIPTION
## What

Under `output.compress`, a dimension argument inside a **preserved** CSS color call kept its leading zero — `rgba(255, 238, 170, 0.1)` compressed to `rgba(255,238,170,0.1)` instead of `rgba(255,238,170,.1)`, leaving Jess 2 bytes longer than both Less 4.x and dart-sass on that value.

## Why it happened

A preserved color call (`rgba`/`rgb`/`hsl` in a `.less` document) is re-emitted with the evaluator disabled so authored spellings (`.5`, hue units) survive untouched. But that byte lane collapsed a `Dimension` node to a **plain string** before the compress-aware emitter ran, so its `Dimension` fold (leading-zero trim) could never fire — the classification was thrown away one step too early. The argument was never stored differently; a `0.1` in an arg is the same `Dimension` node it is anywhere else.

## Fix

Fold the dimension by its node classification at the single shared chokepoint — the `Dimension` case in `evalValue` — matching what the typed lane already does via `emitValueC`. It reads the node type and trims the authored bytes; it never re-scans the joined argument string. One guard, every caller.

- `rgba(255, 238, 170, 0.1)` → `rgba(255,238,170,.1)`
- `rgb(15 23 42 / 0.5)` → `rgb(15 23 42 / .5)` (separators kept, alpha folds)
- Custom-property values are untouched — they parse as opaque `Any`, never reaching this case.
- Hex args already folded (the `Color` case never gated on the evaluator).

## Fixture graduation

The `compression` fixture carried a dead `^` / `^^` parent-selector block (Shadow-DOM piercing, removed in Less 5) that stopped it parsing. That block is removed on the test-data corpus and the golden regenerated as the v5 compressed output, so the fixture moves off the invalid/skip lists and runs as a passing superset fixture. The regenerated golden also reflects the settled hex 6→3 fold (`#ffeeaa`→`#fea`).

> Requires the matching test-data update on the `less.js` fork `alpha` branch (already pushed), which the harness reads.

## Tests

- `packages/core` `src/ast`: 513 pass
- `packages/jess` `compress.test`: 18 pass
- `packages/jess` `less/all-less`: 210 pass (was 209; +1 graduated `compression`)