### PR TITLE
fix(release): make alpha publish self-consistent and mirror npm

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -3,18 +3,33 @@ name: Publish alpha packages
 on:
   workflow_dispatch:
 
+# contents: write so the successful publish can push its release tag
+# (vX.Y.Z-alpha.N). id-token: write is the OIDC grant for npm trusted publishing.
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   publish-alpha:
     runs-on: ubuntu-latest
+    # The preflight runs the corpus-backed jess tests (test/less/*.test.ts via
+    # resolveLessTestDataRoot). They resolve the @less/test-data corpus from a
+    # sibling checkout that is absent in CI; point them at the corpus checked out
+    # below, exactly as ci.yml does — without it the preflight fails to load them.
+    env:
+      LESS_TEST_DATA_ROOT: ${{ github.workspace }}/less-corpus/packages/test-data
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Checkout Less.js corpus (matthew-dean/less.js@alpha)
+        uses: actions/checkout@v4
+        with:
+          repository: matthew-dean/less.js
+          ref: alpha
+          path: less-corpus
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -44,4 +59,25 @@ jobs:
         run: pnpm run release:alpha:check
 
       - name: Publish allowlisted alpha packages
+        id: publish
         run: pnpm run release:alpha:publish
+
+      # Record the published version in git so the repo mirrors npm. The alpha
+      # branch is a disposable projection of dev, so the durable record is the
+      # tag (which also bypasses branch protection, unlike a branch push).
+      - name: Record the published version as a git tag
+        if: success() && steps.publish.outputs.version != ''
+        env:
+          VERSION: ${{ steps.publish.outputs.version }}
+        run: |
+          TAG="v$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists; nothing to record."
+          else
+            git tag -a "$TAG" -m "Release $TAG"
+            git push origin "$TAG"
+            echo "Pushed tag $TAG."
+          fi
+          echo "Tagged \`$TAG\`." >> "$GITHUB_STEP_SUMMARY"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -57,8 +57,15 @@ pnpm run release:alpha
 2. Re-run `pnpm run release:alpha:publish`.
 3. Already-published versions are skipped automatically.
 
-## CI backup (manual only)
+## Publishing via CI (OIDC trusted publishing)
 
 - Workflow: `.github/workflows/publish-alpha.yml`
-- Trigger: `workflow_dispatch` only
-- Recommended default is still CLI (`pnpm run release:alpha`) so release ownership stays explicit.
+- Trigger: `workflow_dispatch` only (release ownership stays explicit — a publish
+  is never a side effect of a push or merge).
+- Publishes to npm with OIDC trusted publishing — no npm token is stored.
+- Runs `release:alpha:check` (full preflight) first; a failing preflight stops it
+  before anything reaches npm.
+- On a successful publish it pushes the annotated release tag `vX.Y.Z-alpha.N`, so
+  the repo mirrors npm exactly like the local `pnpm run release:alpha` flow does.
+- Requires the `alpha` branch to already carry the cut's resolved version (the
+  `update-alpha-from-dev` cut writes it), which it will on a correctly cut snapshot.

--- a/docs/process/releasing-alpha.md
+++ b/docs/process/releasing-alpha.md
@@ -177,10 +177,18 @@ The updater implements this controlled snapshot procedure:
    manifest versions, so alpha-only release notes or source changes must land
    on dev first. The snapshot must keep
    every current `dev` manifest field—especially dependencies, peer ranges,
-   exports, and publish configuration—and retain only the recovery alpha
-   versions until the registry-aware release step selects the next version.
+   exports, and publish configuration—changing only the lockstep `version`.
    This also preserves `dev`'s root scripts, release/readiness evidence, and
    handoff documentation; `pnpm-lock.yaml` remains unchanged.
+
+   The updater then sets the lockstep `version` across every publishable
+   manifest to the exact version this cut will publish — the npm `alpha`
+   dist-tag **+ 1**, from the registry-aware resolver (`resolveAlphaPublishVersion`).
+   So the `alpha` branch, its release tag, and npm all carry the same number
+   (no placeholder version on the branch), and the publish-time clobber guard
+   passes without a separate manual `increment-alpha` step. This is drift-free:
+   the resolver keys off what is actually published, so a cut that never
+   publishes resolves the same number next time rather than climbing the manifest.
 4. Reconcile the owner-reviewed release notes from the final gate evidence,
    commit one controlled refresh on `alpha`, and confirm a clean source tree.
 
@@ -218,9 +226,17 @@ flow.
 
 After the controlled snapshot is committed, run the preflight and release commands
 from `alpha` as described below. Do not copy `dev`'s placeholder version onto
-`alpha` manually: the release script's registry-aware resolver selects a fresh
-version. Its alpha-clobber guard deliberately rejects a snapshot whose
-manifest version is at or behind an already-published alpha.
+`alpha` manually: the cut's registry-aware resolver already wrote the fresh
+version (npm `alpha` + 1) into the manifests, so the branch mirrors what will
+publish. The alpha-clobber guard — which rejects a snapshot whose manifest
+version is at or behind an already-published alpha — therefore passes on a
+correctly cut snapshot; if it fires, the cut did not run or `dev`'s placeholder
+leaked through.
+
+When publishing via the `publish-alpha.yml` workflow (OIDC trusted publishing),
+a successful publish also pushes the annotated release tag `vX.Y.Z-alpha.N`, so
+publishing through CI records the same git tag the local `release:alpha` flow
+does — the repo mirrors npm either way.
 
 ### Moving the `latest` dist-tag during the alpha phase (gated, off by default)
 

--- a/scripts/release/__tests__/update-alpha-from-dev.test.ts
+++ b/scripts/release/__tests__/update-alpha-from-dev.test.ts
@@ -103,10 +103,19 @@ describe('update-alpha-from-dev release helper', () => {
     expect(run('git', ['log', '-1', '--pretty=%s'], alpha).trim()).toBe('chore(release): refresh alpha from dev');
     expect(run('git', ['rev-parse', '--verify', 'alpha-pre-refresh-test'], alpha).trim()).toMatch(/^[0-9a-f]{40}$/u);
 
+    /*
+     * The cut sets the manifest to the version this release will PUBLISH, from
+     * the registry-aware resolver (npm 'alpha' + 1). `@fixture/package` is not on
+     * npm, so the resolver returns the intended manifest version as-is — a first
+     * publish ships exactly that version rather than skipping to +1. (The
+     * published+1 branch is covered by resolve-alpha-version.test.ts, which mocks
+     * the registry.) The recovery version (alpha.9) is preserved, not dev's
+     * placeholder (alpha.5).
+     */
     const manifest = JSON.parse(readFileSync(path.join(alpha, 'packages/fixture/package.json'), 'utf8'));
     expect(manifest).toEqual({
       name: '@fixture/package',
-      version: '2.0.0-alpha.10',
+      version: '2.0.0-alpha.9',
       exports: { ['.']: './lib/index.js' },
       peerDependencies: { parseman: '^0.41.0' }
     });

--- a/scripts/release/publish-alpha.mjs
+++ b/scripts/release/publish-alpha.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
 import path from 'node:path';
 import {
   applyLockstepVersion,
@@ -380,6 +381,21 @@ try {
   }
 
   console.log(`\n${options.dryRun ? 'Dry-run checks finished.' : 'Alpha publish finished.'}`);
+
+  /*
+   * Hand the published version back to the CI workflow so it can record the
+   * release as a git tag (`vX.Y.Z-alpha.N`). Only on a real publish — a dry-run
+   * publishes nothing to mirror. `GITHUB_OUTPUT`/`GITHUB_STEP_SUMMARY` are only
+   * set inside GitHub Actions, so this is a no-op locally.
+   */
+  if (!options.dryRun) {
+    if (process.env.GITHUB_OUTPUT) {
+      appendFileSync(process.env.GITHUB_OUTPUT, `version=${publishVersion}\n`);
+    }
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `Published alpha \`${publishVersion}\` to npm.\n`);
+    }
+  }
 } finally {
   if (restoreVersions) {
     restoreVersions();

--- a/scripts/release/update-alpha-from-dev.mjs
+++ b/scripts/release/update-alpha-from-dev.mjs
@@ -6,7 +6,7 @@ import {
   currentBranch,
   fetchAlphaSource
 } from './alpha-source-sync.mjs';
-import { isReleaseArtifactPath } from './release-utils.mjs';
+import { applyLockstepVersion, isReleaseArtifactPath, resolveAlphaPublishVersion } from './release-utils.mjs';
 
 const scriptDir = new URL('.', import.meta.url);
 
@@ -212,10 +212,18 @@ function main() {
   runNodeHelper(rootDir, 'restore-alpha-package-versions.mjs', ['--from', recoveryRef, '--stage']);
   runNodeHelper(rootDir, 'record-alpha-source-provenance.mjs', ['--stage']);
 
-  /* The registry-aware resolver in release-alpha owns the version (always
-   * published+1). Bumping here too made every cut climb the manifest, so cuts
-   * that never published drifted it ahead of npm. The snapshot keeps the
-   * recovery ref's version; the release step resolves and applies the real one. */
+  /* Set the manifest to the EXACT version this cut will publish -- the npm
+   * 'alpha' dist-tag + 1, from the registry-aware resolver. This makes the alpha
+   * branch, its release tag, and npm all agree (no placeholder version on the
+   * branch) and clears the publish-time clobber guard without a separate manual
+   * `increment-alpha` step. It is drift-free: the resolver keys off what is
+   * actually published, so a cut that never publishes resolves the same number
+   * next time rather than climbing the manifest. */
+  const publishVersion = resolveAlphaPublishVersion({ rootDir }).resolved;
+  const applied = applyLockstepVersion(rootDir, publishVersion);
+  console.log(`Set alpha manifest to publish version ${publishVersion} `
+    + `(npm 'alpha' + 1) across ${applied.changed.length} manifest(s).`);
+
   if (!options.skipInstall) {
     run('pnpm', ['install'], rootDir);
   }


### PR DESCRIPTION
## Why

Cutting and publishing this alpha surfaced three surprises in the OIDC publish path:

1. **Preflight couldn't pass.** The corpus-backed fixture suite (`test:less:test-data`) needs the `@less/test-data` checkout that `ci.yml` provides but `publish-alpha.yml` did not — so the run failed with `Unable to resolve @less/test-data` before it ever reached the publish step. (This is exactly what blocked the alpha.18 publish attempt; nothing reached npm.)
2. **Publishing left no git record.** The workflow was `contents: read` and never tagged, so a CI publish produced an npm release with no matching tag or version in git. Only the local `release:alpha` CLI recorded one — so the credential-free path everyone should prefer was the one that recorded nothing.
3. **A cut needed a hidden manual step.** `update-alpha-from-dev` kept the recovery version, so the publish-time clobber guard refused (`Run increment-alpha.mjs`) until someone bumped by hand.

## What changed

**`publish-alpha.yml`**
- Checks out `matthew-dean/less.js@alpha` into `less-corpus` and sets `LESS_TEST_DATA_ROOT` (mirrors `ci.yml`) — unblocks the preflight.
- `permissions: contents: write`, and after a successful publish pushes the annotated tag `vX.Y.Z-alpha.N`. The `alpha` branch is a disposable projection, and tags bypass branch protection, so the tag is the durable git mirror of npm.

**`update-alpha-from-dev.mjs`**
- Writes the exact publish version (npm `alpha` + 1, from the registry-aware `resolveAlphaPublishVersion`) into the manifests at cut time. Now the `alpha` branch, its tag, and npm all carry the same version — no placeholder on the branch — and the clobber guard passes with no manual `increment-alpha`. Drift-free: the resolver keys off what is actually published, so a cut that never publishes resolves the same number next time.

**`publish-alpha.mjs`**
- Hands the resolved version back via `GITHUB_OUTPUT` for the tag step (no-op locally).

## Net effect (Law of Least Surprise)

- Merging/pushing to `alpha` still never auto-publishes — publish stays a deliberate `workflow_dispatch`.
- A successful publish (CLI **or** CI) now always records `vX.Y.Z-alpha.N` in git, and the `alpha` manifest matches what's on npm.
- The cut is one step: project dev → the version is already set → dispatch publish.

## Tests
- Fixes a pre-existing red in `update-alpha-from-dev.test.ts` (it asserted a manifest+1 bump; the registry resolver correctly ships the *intended* version for a never-published package rather than skipping to +1). All 4 release-script test files green (37 tests).
- Docs updated (`RELEASES.md`, `docs/process/releasing-alpha.md`).

> Note: the workflow change only takes effect once it's on `alpha` (workflow_dispatch runs the file from the dispatched ref), so after merge I'll re-cut `alpha` from `dev` and re-attempt the alpha.18 publish.