### PR TITLE
fix(release): clone the alpha corpus outside the repo tree

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -14,22 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     # The preflight runs the corpus-backed jess tests (test/less/*.test.ts via
     # resolveLessTestDataRoot). They resolve the @less/test-data corpus from a
-    # sibling checkout that is absent in CI; point them at the corpus checked out
-    # below, exactly as ci.yml does — without it the preflight fails to load them.
+    # sibling checkout that is absent in CI; point them at the corpus cloned
+    # below. It is cloned OUTSIDE the repo (into RUNNER_TEMP) rather than checked
+    # out into the workspace, because the preflight's alpha source-sync gate
+    # requires a clean working tree and would flag a corpus dir under it.
     env:
-      LESS_TEST_DATA_ROOT: ${{ github.workspace }}/less-corpus/packages/test-data
+      LESS_TEST_DATA_ROOT: ${{ runner.temp }}/less-corpus/packages/test-data
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Checkout Less.js corpus (matthew-dean/less.js@alpha)
-        uses: actions/checkout@v4
-        with:
-          repository: matthew-dean/less.js
-          ref: alpha
-          path: less-corpus
+      - name: Clone Less.js corpus (matthew-dean/less.js@alpha) outside the repo
+        run: |
+          git clone --quiet --depth 1 --branch alpha --single-branch \
+            https://github.com/matthew-dean/less.js "$RUNNER_TEMP/less-corpus"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Follow-up to #205. The alpha publish preflight got past the missing-corpus error but then failed the **alpha source-sync clean-tree gate**:

```
Alpha source sync requires a clean working tree:
  ?? less-corpus/
```

The corpus was checked out into the workspace (`path: less-corpus`), and the preflight's `verify-alpha-source-sync` runs `git status --porcelain --untracked-files=all` on the repo — so the corpus dir made the tree "dirty". (`ci.yml` doesn't hit this: it has no clean-tree gate.)

**Fix:** clone the corpus into `$RUNNER_TEMP` (outside the repo) instead of checking it out into the workspace, and point `LESS_TEST_DATA_ROOT` there. The corpus never touches the working tree, so the clean-tree gate passes — no `.gitignore` change needed.

Nothing was published in the failed run (the publish step was skipped; npm stays at `alpha.17`).

After merge I'll re-cut `alpha` and re-dispatch the publish.