### PR TITLE
fix(release): set LESS_TEST_DATA_ROOT in-step, not job env

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -12,24 +12,24 @@ permissions:
 jobs:
   publish-alpha:
     runs-on: ubuntu-latest
-    # The preflight runs the corpus-backed jess tests (test/less/*.test.ts via
-    # resolveLessTestDataRoot). They resolve the @less/test-data corpus from a
-    # sibling checkout that is absent in CI; point them at the corpus cloned
-    # below. It is cloned OUTSIDE the repo (into RUNNER_TEMP) rather than checked
-    # out into the workspace, because the preflight's alpha source-sync gate
-    # requires a clean working tree and would flag a corpus dir under it.
-    env:
-      LESS_TEST_DATA_ROOT: ${{ runner.temp }}/less-corpus/packages/test-data
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      # The preflight runs the corpus-backed jess tests (test/less/*.test.ts via
+      # resolveLessTestDataRoot). They resolve the @less/test-data corpus from a
+      # sibling checkout that is absent in CI. Clone it OUTSIDE the repo (into
+      # RUNNER_TEMP) so the preflight's alpha source-sync clean-tree gate does not
+      # flag a corpus dir under the workspace, and publish LESS_TEST_DATA_ROOT to
+      # later steps via GITHUB_ENV (the `runner` context is not available in a
+      # job-level `env:` block, only inside steps).
       - name: Clone Less.js corpus (matthew-dean/less.js@alpha) outside the repo
         run: |
           git clone --quiet --depth 1 --branch alpha --single-branch \
             https://github.com/matthew-dean/less.js "$RUNNER_TEMP/less-corpus"
+          echo "LESS_TEST_DATA_ROOT=$RUNNER_TEMP/less-corpus/packages/test-data" >> "$GITHUB_ENV"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
Follow-up to #206, which had a latent parse error: `${{ runner.temp }}` was used in a **job-level `env:` block**, but the `runner` context is only available inside steps. GitHub therefore failed to parse the workflow entirely:

```
Unrecognized named-value: 'runner'. Located at position 1 within expression: runner.temp
```

Every trigger errored at 0s, and the publish `workflow_dispatch` returned HTTP 422. Because a `workflow_dispatch`-only workflow isn't exercised by PR CI (ci.yml), #206's green checks didn't catch it.

**Fix:** set `LESS_TEST_DATA_ROOT` from inside the corpus-clone step via `$GITHUB_ENV` (where `$RUNNER_TEMP` is valid); the later preflight step inherits it. No job-level `env:` block remains.

Validated with `actionlint` (exit 0) — which would have caught the original error. Nothing published in the failed runs (npm still `alpha.17`).

After merge: re-cut `alpha`, re-dispatch.