### PR TITLE
fix(release): skip the npm login gate under OIDC trusted publishing

### DIFF
--- a/scripts/release/release-utils.mjs
+++ b/scripts/release/release-utils.mjs
@@ -745,6 +745,22 @@ export function ensurePublishAuth() {
   if (process.env.__ALPHA_AUTH_VERIFIED === '1') {
     return;
   }
+
+  /*
+   * [OIDC] Under GitHub Actions trusted publishing (`permissions: id-token: write`)
+   * there is no pre-existing npm login or token: pnpm exchanges the OIDC id-token
+   * for a short-lived publish credential DURING `pnpm publish`. A pre-publish
+   * `npm whoami` / `npm login` gate has nothing to check and, with no TTY, would
+   * fall into the interactive login and fail — blocking a publish that would
+   * otherwise authenticate itself. GitHub injects ACTIONS_ID_TOKEN_REQUEST_URL
+   * only when the id-token permission is granted, so treat its presence as
+   * "OIDC will handle auth" and skip the gate.
+   */
+  if (process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+    process.env.__ALPHA_AUTH_VERIFIED = '1';
+    return;
+  }
+
   const useShell = process.platform === 'win32';
   const whoami = spawnSync('npm', ['whoami'], {
     encoding: 'utf8',


### PR DESCRIPTION
With pnpm 10 in place (#208), the alpha publish **cleared preflight for the first time** and reached the publish step — then failed:

```
Error: npm login failed. Cannot publish without authentication.
Username:  ELIFECYCLE  Command failed with exit code 1.
```

`ensurePublishAuth()` runs `npm whoami` and, when not logged in, `npm login --auth-type=web`. Under GitHub Actions **OIDC trusted publishing** there is no pre-existing login or token — pnpm exchanges the OIDC id-token for a short-lived publish credential *during* `pnpm publish`. So the pre-publish gate has nothing to verify and, with no TTY, falls into the interactive login and throws — blocking a publish that would authenticate itself.

**Fix:** detect `ACTIONS_ID_TOKEN_REQUEST_URL` (which GitHub injects only when `id-token: write` is granted) and skip the auth gate; pnpm owns auth from there. Local/token publishing paths are unchanged.

No partial publish occurred — all 22 packages remain at `alpha.17`.

> Heads-up: the OIDC exchange also requires a **trusted publisher configured on npmjs.com** for each package (repo `jesscss/jess`, workflow `publish-alpha.yml`). If that isn't set up, the next run may fail the exchange with a 403/404 — that's an owner action in each package's npm settings, which I can't do. After merge I'll re-cut + re-dispatch and report exactly what the publish returns.