### PR TITLE
chore(release): add trusted-publisher config helper for OIDC publishing

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -69,3 +69,19 @@ pnpm run release:alpha
   the repo mirrors npm exactly like the local `pnpm run release:alpha` flow does.
 - Requires the `alpha` branch to already carry the cut's resolved version (the
   `update-alpha-from-dev` cut writes it), which it will on a correctly cut snapshot.
+
+### First-time setup: register the trusted publisher (per package)
+
+OIDC publishing only works once each allowlisted package has a GitHub Actions
+trusted publisher registered on npmjs.com (repo `jesscss/jess`, workflow
+`publish-alpha.yml`). Without it the publish fails with `npm error 404 … could not
+be found or you do not have permission`. Configure all allowlisted packages at once
+(npm CLI >= 11.10.0, logged in with publish rights):
+
+```bash
+npm login            # if `npm whoami` fails
+pnpm run release:alpha:trust
+```
+
+This reads `scripts/release/alpha-allowlist.json`, so re-run it after adding a new
+package to the release set.

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "release:alpha:update-from-dev": "node scripts/release/update-alpha-from-dev.mjs",
     "release:alpha:version": "node scripts/release/increment-alpha.mjs",
     "release:alpha:publish": "node scripts/release/publish-alpha.mjs --tag alpha",
+    "release:alpha:trust": "node scripts/release/configure-trusted-publishers.mjs",
     "release:alpha:dry-run": "node scripts/release/release-alpha.mjs --dry-run",
     "release:alpha:pack-dry-run": "node scripts/release/publish-alpha.mjs --dry-run --tag alpha",
     "release:alpha": "node scripts/release/release-alpha.mjs",

--- a/scripts/release/configure-trusted-publishers.mjs
+++ b/scripts/release/configure-trusted-publishers.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/*
+ * Register the GitHub Actions OIDC trusted publisher for every allowlisted alpha
+ * package, so `.github/workflows/publish-alpha.yml` can publish tokenlessly.
+ *
+ * One-time (per package) npmjs.com configuration, scripted off the allowlist so it
+ * stays in sync as packages are added. Requires:
+ *   - npm CLI >= 11.10.0 (the `npm trust` command), and
+ *   - an authenticated npm session with publish rights (`npm whoami` must succeed).
+ *
+ * Usage:
+ *   node scripts/release/configure-trusted-publishers.mjs            # apply
+ *   node scripts/release/configure-trusted-publishers.mjs --dry-run  # preview
+ *
+ * Idempotent: re-registering the same publisher is a no-op on npm's side.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const REPO = 'jesscss/jess';
+const WORKFLOW = 'publish-alpha.yml';
+const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../..');
+const allowlist = JSON.parse(
+  readFileSync(path.join(rootDir, 'scripts/release/alpha-allowlist.json'), 'utf8')
+);
+
+const dryRun = process.argv.includes('--dry-run');
+
+function npmMajorMinorOk() {
+  const v = spawnSync('npm', ['--version'], { encoding: 'utf8' }).stdout?.trim() ?? '';
+  const m = /^(\d+)\.(\d+)/.exec(v);
+  if (!m) {
+    return { ok: false, version: v || '(unknown)' };
+  }
+  const [major, minor] = [Number(m[1]), Number(m[2])];
+  return { ok: major > 11 || (major === 11 && minor >= 10), version: v };
+}
+
+const { ok, version } = npmMajorMinorOk();
+if (!ok) {
+  console.error(`npm ${version} does not have the 'npm trust' command. Upgrade: npm install -g npm@latest`);
+  process.exit(1);
+}
+if (spawnSync('npm', ['whoami'], { encoding: 'utf8' }).status !== 0) {
+  console.error('Not authenticated to npm. Run `npm login` (with publish rights) first.');
+  process.exit(1);
+}
+
+const failed = [];
+for (const pkg of allowlist) {
+  const args = ['trust', 'github', pkg, '--file', WORKFLOW, '--repo', REPO, '--allow-publish', '--yes'];
+  if (dryRun) {
+    args.push('--dry-run');
+  }
+  console.log(`\n$ npm ${args.join(' ')}`);
+  if (spawnSync('npm', args, { stdio: 'inherit' }).status !== 0) {
+    failed.push(pkg);
+  }
+}
+
+if (failed.length > 0) {
+  console.error(`\nFailed to configure ${failed.length} package(s):\n- ${failed.join('\n- ')}`);
+  process.exit(1);
+}
+console.log(`\nTrusted publisher (${REPO} / ${WORKFLOW}) configured for ${allowlist.length} package(s).`);


### PR DESCRIPTION
The alpha publish now works end-to-end up to npm, where it fails with:

```
npm error 404  The requested resource '@jesscss/awaitable-pipe@2.0.0-alpha.18'
could not be found or you do not have permission to access it.
```

That's OIDC's "no trusted publisher registered" error — each allowlisted package needs a GitHub Actions trusted publisher configured on npmjs.com (repo `jesscss/jess`, workflow `publish-alpha.yml`). npm 11.10+ added a CLI for this, so this adds a scripted, allowlist-driven helper instead of clicking through 22 package settings pages:

```bash
npm login                      # if `npm whoami` fails
pnpm run release:alpha:trust   # loops all allowlisted packages
```

- `scripts/release/configure-trusted-publishers.mjs` runs `npm trust github <pkg> --file publish-alpha.yml --repo jesscss/jess --allow-publish --yes` for every entry in `alpha-allowlist.json`.
- Guards on npm ≥ 11.10.0 and an authenticated session; supports `--dry-run`; idempotent.
- Documented as first-time setup in `RELEASES.md`.

**This is a helper, not the config itself** — it must be run by an account with publish rights to the packages (owner), since only that account can register their trusted publishers. Once run, the publish workflow should complete tokenlessly.