### PR TITLE
fix(release): point package repository.url at jesscss/jess for provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,14 +179,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/matthew-dean/jess.git"
+    "url": "git+https://github.com/jesscss/jess.git"
   },
   "author": "Matthew Dean <matthew-dean@users.noreply.github.com>",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/matthew-dean/jess/issues"
+    "url": "https://github.com/jesscss/jess/issues"
   },
-  "homepage": "https://github.com/matthew-dean/jess#readme",
+  "homepage": "https://github.com/jesscss/jess#readme",
   "pnpm": {
     "patchedDependencies": {
       "superstruct@1.0.3": "patches/superstruct@1.0.3.patch",

--- a/packages/awaitable-pipe/package.json
+++ b/packages/awaitable-pipe/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/awaitable-pipe",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/awaitable-pipe"
+  },
   "version": "2.0.0-alpha.5",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
@@ -29,10 +34,6 @@
     "test:types": "tsc -p tsconfig.json --noEmit",
     "test:watch": "vitest",
     "compile": "tsdown --tsconfig tsconfig.build.json --no-dts && tsc -p tsconfig.build.json --emitDeclarationOnly"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/matthew-dean/jess.git"
   },
   "keywords": [
     "pipe",

--- a/packages/compiler-preset/package.json
+++ b/packages/compiler-preset/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/compiler-preset",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/compiler-preset"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/compiler",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/compiler"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,10 @@
 {
   "name": "styles-config",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/config"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/core",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/core"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/diagnostics-core/package.json
+++ b/packages/diagnostics-core/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/diagnostics-core",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/diagnostics-core"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/fns/package.json
+++ b/packages/fns/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/fns",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/fns"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/jess-plugin-js/package.json
+++ b/packages/jess-plugin-js/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/plugin-js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/jess-plugin-js"
+  },
   "version": "2.0.0-alpha.5",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/packages/jess-plugin-node-modules/package.json
+++ b/packages/jess-plugin-node-modules/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/plugin-node-modules",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/jess-plugin-node-modules"
+  },
   "version": "2.0.0-alpha.5",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/packages/jess/package.json
+++ b/packages/jess/package.json
@@ -1,5 +1,10 @@
 {
   "name": "jess",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/jess"
+  },
   "type": "module",
   "version": "2.0.0-alpha.5",
   "description": "JavaScript Enhanced Style Sheets",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/lint",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/lint"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/parser-shared/package.json
+++ b/packages/parser-shared/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/parser-shared",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/parser-shared"
+  },
   "version": "2.0.0-alpha.5",
   "type": "module",
   "publishConfig": {

--- a/packages/patch-css/package.json
+++ b/packages/patch-css/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/patch-css",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/patch-css"
+  },
   "type": "module",
   "version": "2.0.0-alpha.5",
   "engines": {

--- a/packages/style-resolver/package.json
+++ b/packages/style-resolver/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/style-resolver",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/style-resolver"
+  },
   "version": "2.0.0-alpha.5",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/packages/syntax/css/css-parser/package.json
+++ b/packages/syntax/css/css-parser/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/css-parser",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/syntax/css/css-parser"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/syntax/jess/jess-parser/package.json
+++ b/packages/syntax/jess/jess-parser/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/jess-parser",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/syntax/jess/jess-parser"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/syntax/jess/jess-plugin-jess/package.json
+++ b/packages/syntax/jess/jess-plugin-jess/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@jesscss/plugin-jess",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/syntax/jess/jess-plugin-jess"
+  },
   "type": "module",
-  "publishConfig": { "access": "public" },
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "The Jess stylesheet parser plugin for Jess",
   "version": "2.0.0-alpha.5",
   "engines": {
@@ -17,7 +24,9 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["lib"],
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "ci": "pnpm build && pnpm test",
     "prepublishOnly": "npm run build",
@@ -34,7 +43,9 @@
   "devDependencies": {},
   "author": "Matthew Dean <matthew-dean@users.noreply.github.com>",
   "license": "MIT",
-  "bugs": { "url": "https://github.com/jesscss/jess/issues" },
+  "bugs": {
+    "url": "https://github.com/jesscss/jess/issues"
+  },
   "homepage": "https://github.com/jesscss/jess#readme",
   "module": "lib/index.js"
 }

--- a/packages/syntax/less/jess-plugin-less-compat/package.json
+++ b/packages/syntax/less/jess-plugin-less-compat/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/plugin-less-compat",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/syntax/less/jess-plugin-less-compat"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/syntax/less/jess-plugin-less/package.json
+++ b/packages/syntax/less/jess-plugin-less/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/plugin-less",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/syntax/less/jess-plugin-less"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/syntax/less/less-parser/package.json
+++ b/packages/syntax/less/less-parser/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/less-parser",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/syntax/less/less-parser"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/syntax/scss/jess-plugin-scss/package.json
+++ b/packages/syntax/scss/jess-plugin-scss/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/plugin-scss",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/syntax/scss/jess-plugin-scss"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/syntax/scss/scss-parser/package.json
+++ b/packages/syntax/scss/scss-parser/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@jesscss/scss-parser",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jesscss/jess.git",
+    "directory": "packages/syntax/scss/scss-parser"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
The OIDC publish now works — it authenticates, publishes, and signs a provenance statement — but npm rejects the very last step with:

```
npm error code E422
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/matthew-dean/jess.git",
expected to match "https://github.com/jesscss/jess" from provenance
```

npm provenance embeds the building repo (`jesscss/jess`) in the signed statement and **requires each published package's `repository.url` to be present and match**. `@jesscss/awaitable-pipe` (first in publish order) still pointed at the old personal fork `matthew-dean/jess`, and the other 21 allowlisted packages had **no `repository` field at all** — both fail provenance.

**Fix:** add `repository { type, url: jesscss/jess, directory }` to all 22 allowlisted packages (directory per monorepo path), and correct the root `package.json` `repository`/`bugs`/`homepage` URLs. No stale `matthew-dean/jess` refs remain in any package manifest.

No partial publish occurred — all packages remain `alpha.17`.

After merge I'll re-cut `alpha` and re-dispatch; the publish should complete.